### PR TITLE
feat(windows): add DXGI, WGC, and WASAPI capture backends 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,6 +910,7 @@ version = "0.1.1"
 dependencies = [
  "pinray-core",
  "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -1511,16 +1512,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -16,9 +16,11 @@ pub enum BackendPreference {
 pub enum BackendKind {
     LinuxWaylandPortal,
     LinuxX11,
+    LinuxPipeWireAudio,
     MacScreenCaptureKit,
     WindowsDxgi,
     WindowsWgc,
+    WindowsWasapi,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -83,11 +83,23 @@ impl CaptureSession {
         match (self.video_backend.as_mut(), self.audio_backend.as_mut()) {
             (Some(video), None) => video.next_event(timeout),
             (None, Some(audio)) => audio.next_audio(timeout).map(CaptureEvent::Audio),
-            (Some(video), Some(audio)) => match video.next_event(timeout) {
-                Ok(event) => Ok(event),
-                Err(PinrayError::Timeout(_)) => audio.next_audio(timeout).map(CaptureEvent::Audio),
-                Err(error) => Err(error),
-            },
+            (Some(video), Some(audio)) => {
+                // Drain pending audio first (non-blocking); otherwise a busy
+                // video stream would starve audio, since audio is only polled
+                // after a video timeout.
+                match audio.next_audio(Some(Duration::ZERO)) {
+                    Ok(frame) => return Ok(CaptureEvent::Audio(frame)),
+                    Err(PinrayError::Timeout(_)) => {}
+                    Err(error) => return Err(error),
+                }
+                match video.next_event(timeout) {
+                    Ok(event) => Ok(event),
+                    Err(PinrayError::Timeout(_)) => {
+                        audio.next_audio(timeout).map(CaptureEvent::Audio)
+                    }
+                    Err(error) => Err(error),
+                }
+            }
             (None, None) => Err(PinrayError::BackendNotSelected),
         }
     }
@@ -181,7 +193,17 @@ impl SessionBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::SessionBuilder;
+    use std::collections::VecDeque;
+    use std::time::Duration;
+
+    use super::{CaptureSession, SessionBuilder};
+    use crate::{
+        audio::{AudioData, AudioFrame, SampleFormat},
+        backend::{AudioBackend, BackendBundle, BackendInfo, BackendKind, VideoBackend},
+        config::SessionConfig,
+        error::{PinrayError, Result},
+        frame::{CaptureEvent, FrameData, PixelFormat, VideoFrame},
+    };
 
     #[test]
     fn builder_requires_video_or_audio() {
@@ -193,5 +215,94 @@ mod tests {
     fn queue_depth_must_be_positive() {
         let config = SessionBuilder::new().queue_depth(0).config().clone();
         assert!(config.validate().is_err());
+    }
+
+    fn mock_info() -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::LinuxWaylandPortal,
+            supports_audio: true,
+            zero_copy: false,
+            notes: "mock",
+        }
+    }
+
+    /// Video backend that always has a frame ready.
+    struct BusyVideo;
+
+    impl VideoBackend for BusyVideo {
+        fn info(&self) -> BackendInfo {
+            mock_info()
+        }
+        fn start(&mut self) -> Result<()> {
+            Ok(())
+        }
+        fn stop(&mut self) -> Result<()> {
+            Ok(())
+        }
+        fn next_event(&mut self, _timeout: Option<Duration>) -> Result<CaptureEvent> {
+            Ok(CaptureEvent::Video(VideoFrame {
+                stream_time_ns: 0,
+                sequence: 0,
+                width: 1,
+                height: 1,
+                stride: 4,
+                pixel_format: PixelFormat::Bgra8888,
+                color_space: None,
+                data: FrameData::Host(vec![0; 4]),
+                damage: None,
+            }))
+        }
+    }
+
+    struct QueuedAudio(VecDeque<AudioFrame>);
+
+    impl AudioBackend for QueuedAudio {
+        fn info(&self) -> BackendInfo {
+            mock_info()
+        }
+        fn start(&mut self) -> Result<()> {
+            Ok(())
+        }
+        fn stop(&mut self) -> Result<()> {
+            Ok(())
+        }
+        fn next_audio(&mut self, timeout: Option<Duration>) -> Result<AudioFrame> {
+            self.0
+                .pop_front()
+                .ok_or(PinrayError::Timeout(timeout.unwrap_or_default()))
+        }
+    }
+
+    #[test]
+    fn busy_video_does_not_starve_audio() {
+        let audio_frame = AudioFrame {
+            stream_time_ns: 0,
+            sequence: 0,
+            sample_rate: 48_000,
+            channels: 2,
+            sample_format: SampleFormat::F32,
+            data: AudioData::Interleaved(vec![0; 8]),
+        };
+        let bundle = BackendBundle {
+            info: mock_info(),
+            video: Some(Box::new(BusyVideo)),
+            audio: Some(Box::new(QueuedAudio(VecDeque::from([
+                audio_frame.clone(),
+                audio_frame,
+            ])))),
+        };
+        let mut session = CaptureSession::new(SessionConfig::default(), bundle);
+
+        let mut audio_events = 0;
+        let mut video_events = 0;
+        for _ in 0..6 {
+            match session.next_event(Some(Duration::from_millis(1))).unwrap() {
+                CaptureEvent::Audio(_) => audio_events += 1,
+                CaptureEvent::Video(_) => video_events += 1,
+                other => panic!("unexpected event: {other:?}"),
+            }
+        }
+        assert_eq!(audio_events, 2, "queued audio must be drained");
+        assert_eq!(video_events, 4);
     }
 }

--- a/crates/pinray/examples/audio_smoke.rs
+++ b/crates/pinray/examples/audio_smoke.rs
@@ -1,0 +1,64 @@
+//! Audio-only smoke test: captures the system mix without any video target.
+//! Works on Linux (PipeWire sink monitor, no portal dialog) and Windows
+//! (WASAPI loopback). Play some audio while it runs.
+//!
+//! ```text
+//! cargo run --example audio_smoke
+//! ```
+
+use std::time::Duration;
+
+use pinray::{AudioCapture, CaptureSession};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "debug".into()),
+        )
+        .init();
+
+    println!("[1] building audio-only session...");
+    let mut session = CaptureSession::builder()
+        .audio(AudioCapture::SystemMix)
+        .build()?;
+
+    println!("[2] backend: {:?}", session.backend_info().kind);
+    println!("[3] starting...");
+    session.start()?;
+
+    let mut received = 0u32;
+    for idx in 0..20 {
+        match session.next_audio(Some(Duration::from_secs(3))) {
+            Ok(frame) => {
+                received += 1;
+                let byte_count = match &frame.data {
+                    pinray::AudioData::Interleaved(bytes) => bytes.len(),
+                    pinray::AudioData::Planar(planes) => planes.iter().map(Vec::len).sum(),
+                };
+                println!(
+                    "[4] audio #{idx}: seq={} rate={} ch={} fmt={:?} bytes={}",
+                    frame.sequence, frame.sample_rate, frame.channels, frame.sample_format, byte_count,
+                );
+            }
+            Err(pinray::PinrayError::Timeout(_)) => {
+                println!("[4] audio #{idx}: timeout (is anything playing?)");
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    println!("[5] stop -> start -> stop (lifecycle test)...");
+    session.stop()?;
+    session.start()?;
+    match session.next_audio(Some(Duration::from_secs(3))) {
+        Ok(_) => println!("[6] second-run audio received"),
+        Err(pinray::PinrayError::Timeout(_)) => println!("[6] second-run: timeout"),
+        Err(error) => return Err(error.into()),
+    }
+    session.stop()?;
+
+    assert!(received > 0, "expected at least one audio frame");
+    println!("[7] done. {received} audio frames. smoke test passed.");
+    Ok(())
+}

--- a/crates/pinray/examples/wayland_smoke.rs
+++ b/crates/pinray/examples/wayland_smoke.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 use pinray::{
-    BackendPreference, CaptureEvent, CaptureSession, PixelFormat, SourceId, VideoCaptureTarget,
+    AudioCapture, BackendPreference, CaptureEvent, CaptureSession, PixelFormat, SourceId,
+    VideoCaptureTarget,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,12 +13,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    println!("[1] building session...");
+    println!("[1] building session (video + system audio)...");
     let mut session = CaptureSession::builder()
         .backend_preference(BackendPreference::LinuxWaylandPortal)
         .video_target(VideoCaptureTarget::Display(SourceId::new(
             "portal-default-display",
         )))
+        .audio(AudioCapture::SystemMix)
         .pixel_format(PixelFormat::Bgra8888)
         .build()?;
 
@@ -26,12 +28,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     session.start()?;
     println!("[4] session started, entering capture loop...");
 
-    for idx in 0..5 {
-        println!("[5] waiting for event #{idx}...");
+    let mut videos = 0u32;
+    let mut audios = 0u32;
+    for idx in 0..15 {
         match session.next_event(Some(Duration::from_secs(10)))? {
             CaptureEvent::Video(frame) => {
+                videos += 1;
                 println!(
-                    "[6] frame #{idx}: {}x{} stride={} format={:?} bytes={}",
+                    "[5] video #{idx}: {}x{} stride={} format={:?} bytes={}",
                     frame.width,
                     frame.height,
                     frame.stride,
@@ -42,12 +46,39 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 );
             }
-            other => println!("[6] event #{idx}: {:?}", other),
+            CaptureEvent::Audio(frame) => {
+                audios += 1;
+                println!(
+                    "[5] audio #{idx}: rate={} ch={} fmt={:?} bytes={}",
+                    frame.sample_rate,
+                    frame.channels,
+                    frame.sample_format,
+                    match frame.data {
+                        pinray::AudioData::Interleaved(ref bytes) => bytes.len(),
+                        pinray::AudioData::Planar(ref planes) =>
+                            planes.iter().map(Vec::len).sum(),
+                    }
+                );
+            }
+            other => println!("[5] event #{idx}: {:?}", other),
         }
     }
 
-    println!("[7] stopping session...");
+    println!("[6] draining audio explicitly...");
+    for idx in 0..3 {
+        match session.next_audio(Some(Duration::from_secs(2))) {
+            Ok(frame) => {
+                audios += 1;
+                println!("[7] audio #{idx}: rate={} ch={}", frame.sample_rate, frame.channels);
+            }
+            Err(pinray::PinrayError::Timeout(_)) => println!("[7] audio #{idx}: timeout (system silent?)"),
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    println!("[8] stopping session...");
     session.stop()?;
-    println!("[8] done.");
+    assert!(videos > 0, "expected at least one video frame");
+    println!("[9] done. videos={videos} audios={audios}. smoke test passed.");
     Ok(())
 }

--- a/crates/pinray/examples/windows_smoke.rs
+++ b/crates/pinray/examples/windows_smoke.rs
@@ -1,0 +1,147 @@
+//! Windows smoke test: source enumeration, DXGI/WGC display capture with
+//! WASAPI loopback audio, and a stop → start → stop lifecycle pass.
+//!
+//! Run on a real Windows host:
+//!
+//! ```text
+//! cargo run --example windows_smoke            # Auto policy (DXGI first)
+//! PINRAY_BACKEND=wgc cargo run --example windows_smoke
+//! ```
+
+use std::time::Duration;
+
+use pinray::{
+    AudioCapture, BackendPreference, CaptureEvent, CaptureSession, FrameData, PixelFormat,
+    SourceId, VideoCaptureTarget,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "debug".into()),
+        )
+        .init();
+
+    let preference = match std::env::var("PINRAY_BACKEND").as_deref() {
+        Ok("wgc") => BackendPreference::WindowsWgc,
+        Ok("dxgi") => BackendPreference::WindowsDxgi,
+        _ => BackendPreference::Auto,
+    };
+
+    println!("[1] available backends:");
+    for backend in pinray::available_backends() {
+        println!("    {:?}: {}", backend.kind, backend.notes);
+    }
+
+    println!("[2] enumerating sources...");
+    let sources = pinray::enumerate_sources()?;
+    for src in sources.iter().take(15) {
+        println!("    source: {src:?}");
+    }
+    println!("    ({} sources total)", sources.len());
+
+    println!("[3] building capture session (primary display + system audio)...");
+    let mut session = CaptureSession::builder()
+        .backend_preference(preference)
+        .video_target(VideoCaptureTarget::Display(SourceId::new("auto")))
+        .audio(AudioCapture::SystemMix)
+        .pixel_format(PixelFormat::Bgra8888)
+        .build()?;
+
+    println!("[4] backend: {:?}", session.backend_info().kind);
+    println!(
+        "    supports_audio={} zero_copy={}",
+        session.backend_info().supports_audio,
+        session.backend_info().zero_copy,
+    );
+
+    println!("[5] starting...");
+    session.start()?;
+
+    let mut videos = 0u32;
+    let mut audios = 0u32;
+    for idx in 0..10 {
+        // DXGI only delivers frames when the desktop changes, so a timeout
+        // here is not fatal — move the mouse or play a video while testing.
+        match session.next_event(Some(Duration::from_secs(5))) {
+            Ok(CaptureEvent::Video(frame)) => {
+                videos += 1;
+                let byte_count = match &frame.data {
+                    FrameData::Host(b) => b.len(),
+                    _ => 0,
+                };
+                println!(
+                    "[6] video #{idx}: {}x{} stride={} format={:?} time_ns={} bytes={}",
+                    frame.width,
+                    frame.height,
+                    frame.stride,
+                    frame.pixel_format,
+                    frame.stream_time_ns,
+                    byte_count,
+                );
+                assert!(
+                    byte_count >= (frame.width * frame.height * 4) as usize,
+                    "frame data smaller than expected: got {byte_count} want {}",
+                    frame.width * frame.height * 4
+                );
+            }
+            Ok(CaptureEvent::Audio(frame)) => {
+                audios += 1;
+                println!(
+                    "[6] audio #{idx}: rate={} ch={} fmt={:?} time_ns={}",
+                    frame.sample_rate, frame.channels, frame.sample_format, frame.stream_time_ns,
+                );
+            }
+            Ok(other) => println!("[6] other event #{idx}: {other:?}"),
+            Err(pinray::PinrayError::Timeout(_)) => {
+                println!("[6] event #{idx}: timeout (desktop idle?)");
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    println!("[7] draining audio explicitly...");
+    for idx in 0..3 {
+        match session.next_audio(Some(Duration::from_secs(2))) {
+            Ok(frame) => {
+                audios += 1;
+                println!(
+                    "[8] audio #{idx}: rate={} ch={} samples_bytes={}",
+                    frame.sample_rate,
+                    frame.channels,
+                    match &frame.data {
+                        pinray::AudioData::Interleaved(b) => b.len(),
+                        pinray::AudioData::Planar(p) => p.iter().map(Vec::len).sum(),
+                    }
+                );
+            }
+            Err(pinray::PinrayError::Timeout(_)) => println!("[8] audio #{idx}: timeout"),
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    println!("[9] stopping...");
+    session.stop()?;
+
+    println!("[10] stop -> start -> stop (lifecycle test)...");
+    session.start()?;
+    match session.next_event(Some(Duration::from_secs(5))) {
+        Ok(event) => println!("[11] second-run event kind: {}", event_kind(&event)),
+        Err(pinray::PinrayError::Timeout(_)) => println!("[11] second-run: timeout"),
+        Err(error) => return Err(error.into()),
+    }
+    session.stop()?;
+
+    println!("[12] done. videos={videos} audios={audios}. smoke test passed.");
+    Ok(())
+}
+
+fn event_kind(event: &CaptureEvent) -> &'static str {
+    match event {
+        CaptureEvent::Video(_) => "Video",
+        CaptureEvent::Audio(_) => "Audio",
+        CaptureEvent::Gap(_) => "Gap",
+        CaptureEvent::End => "End",
+    }
+}

--- a/crates/pinray/src/lib.rs
+++ b/crates/pinray/src/lib.rs
@@ -1,11 +1,11 @@
-use pinray_core::{BackendBundle, BackendResolver, PinrayError, Result, SessionConfig};
+use pinray_core::{BackendBundle, BackendResolver, Result, SessionConfig};
 
 pub use pinray_core::{
     AudioCapture, AudioData, AudioDeviceSource, AudioFrame, BackendInfo, BackendKind,
     BackendPreference, CaptureEvent, CaptureSource, ColorSpace, CursorMode, CvPixelBufferHandle,
-    D3D11TextureHandle, DisplaySource, DmabufFrame, FrameData, GapEvent, GapReason, PixelFormat,
-    Rect, SampleFormat, SessionConfig as CoreSessionConfig, SourceId, VideoCaptureTarget,
-    VideoFrame, WindowSource,
+    D3D11TextureHandle, DisplaySource, DmabufFrame, FrameData, GapEvent, GapReason, PinrayError,
+    PixelFormat, Rect, SampleFormat, SessionConfig as CoreSessionConfig, SourceId,
+    VideoCaptureTarget, VideoFrame, WindowSource,
 };
 
 pub struct CaptureSession {

--- a/crates/platform-linux/src/audio.rs
+++ b/crates/platform-linux/src/audio.rs
@@ -1,0 +1,318 @@
+//! PipeWire system-audio capture (sink monitor).
+//!
+//! Connects a native PipeWire capture stream with `stream.capture.sink=true`,
+//! which makes the session manager route the default output's monitor ports
+//! to us — i.e. the system mix. No portal round-trip is needed for audio and
+//! nothing shells out to `pactl`.
+//!
+//! Mirrors the worker-thread pattern of the Wayland video backend: the
+//! PipeWire main loop runs on a dedicated thread, frames flow through a
+//! bounded queue into an mpsc channel, and start/stop/terminate arrive over
+//! a control channel.
+
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex, mpsc},
+    thread,
+    time::Duration,
+};
+
+use pipewire::{
+    self as pw,
+    context::ContextRc,
+    main_loop::MainLoopRc,
+    properties::properties,
+    spa::{
+        param::{
+            ParamType,
+            audio::{AudioFormat, AudioInfoRaw},
+            format::{MediaSubtype, MediaType},
+        },
+        pod::Pod,
+        utils::{Direction, SpaTypes},
+    },
+    stream::{StreamFlags, StreamListener, StreamRc},
+};
+
+use pinray_core::{
+    AudioBackend, AudioData, AudioFrame, BackendInfo, BackendKind, PinrayError, Result,
+    SampleFormat,
+};
+
+/// Cap on frames buffered while the consumer is not draining; oldest packets
+/// are dropped first (~10 ms of audio each).
+const MAX_QUEUED_FRAMES: usize = 512;
+
+pub(crate) struct PipeWireAudioBackend {
+    control_tx: mpsc::Sender<ControlMessage>,
+    event_rx: mpsc::Receiver<AudioFrame>,
+    worker: Option<thread::JoinHandle<Result<()>>>,
+}
+
+impl PipeWireAudioBackend {
+    pub(crate) fn new() -> Result<Self> {
+        let (control_tx, control_rx) = mpsc::channel();
+        let (event_tx, event_rx) = mpsc::channel();
+
+        let worker = thread::Builder::new()
+            .name("pinray-pw-audio".into())
+            .spawn(move || run_audio_loop(control_rx, event_tx))
+            .map_err(|e| PinrayError::Platform(format!("failed to spawn audio thread: {e}")))?;
+
+        Ok(Self {
+            control_tx,
+            event_rx,
+            worker: Some(worker),
+        })
+    }
+
+    pub(crate) fn backend_info() -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::LinuxPipeWireAudio,
+            supports_audio: true,
+            zero_copy: false,
+            notes: "PipeWire system-mix capture via default sink monitor",
+        }
+    }
+}
+
+impl AudioBackend for PipeWireAudioBackend {
+    fn info(&self) -> BackendInfo {
+        Self::backend_info()
+    }
+
+    fn start(&mut self) -> Result<()> {
+        self.control_tx
+            .send(ControlMessage::Start)
+            .map_err(|_| PinrayError::Platform("pipewire audio worker is not available".into()))
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        self.control_tx
+            .send(ControlMessage::Stop)
+            .map_err(|_| PinrayError::Platform("pipewire audio worker is not available".into()))
+    }
+
+    fn next_audio(&mut self, timeout: Option<Duration>) -> Result<AudioFrame> {
+        match timeout {
+            Some(timeout) => self
+                .event_rx
+                .recv_timeout(timeout)
+                .map_err(|error| match error {
+                    mpsc::RecvTimeoutError::Timeout => PinrayError::Timeout(timeout),
+                    mpsc::RecvTimeoutError::Disconnected => {
+                        PinrayError::Platform("pipewire audio channel disconnected".into())
+                    }
+                }),
+            None => self
+                .event_rx
+                .recv()
+                .map_err(|_| PinrayError::Platform("pipewire audio channel disconnected".into())),
+        }
+    }
+}
+
+impl Drop for PipeWireAudioBackend {
+    fn drop(&mut self) {
+        let _ = self.control_tx.send(ControlMessage::Terminate);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ControlMessage {
+    Start,
+    Stop,
+    Terminate,
+}
+
+#[derive(Default)]
+struct UserData {
+    format: AudioInfoRaw,
+}
+
+#[derive(Default)]
+struct RuntimeState {
+    active: bool,
+    sequence: u64,
+}
+
+fn run_audio_loop(
+    control_rx: mpsc::Receiver<ControlMessage>,
+    event_tx: mpsc::Sender<AudioFrame>,
+) -> Result<()> {
+    pw::init();
+
+    let main_loop = MainLoopRc::new(None).map_err(platform_error)?;
+    let context = ContextRc::new(&main_loop, None).map_err(platform_error)?;
+    let core = context.connect_rc(None).map_err(platform_error)?;
+
+    let runtime = Arc::new(Mutex::new(RuntimeState::default()));
+    let queue = Arc::new(Mutex::new(VecDeque::<AudioFrame>::new()));
+
+    let stream_properties = properties! {
+        *pw::keys::MEDIA_TYPE => "Audio",
+        *pw::keys::MEDIA_CATEGORY => "Capture",
+        *pw::keys::MEDIA_ROLE => "Music",
+        // Capture from the default sink's monitor ports = system mix.
+        *pw::keys::STREAM_CAPTURE_SINK => "true",
+    };
+    let stream =
+        StreamRc::new(core, "pinray-system-audio", stream_properties).map_err(platform_error)?;
+
+    let listener = stream
+        .add_local_listener_with_user_data(UserData::default())
+        .param_changed(|_, user_data, id, param| {
+            let Some(param) = param else {
+                return;
+            };
+            if id != ParamType::Format.as_raw() {
+                return;
+            }
+
+            let Ok((media_type, media_subtype)) = pw::spa::param::format_utils::parse_format(param)
+            else {
+                return;
+            };
+            if media_type != MediaType::Audio || media_subtype != MediaSubtype::Raw {
+                return;
+            }
+
+            if let Err(error) = user_data.format.parse(param) {
+                tracing::warn!(error = %error, "pipewire audio format parse failed");
+                return;
+            }
+            tracing::debug!(
+                rate = user_data.format.rate(),
+                channels = user_data.format.channels(),
+                "pipewire audio format negotiated"
+            );
+        })
+        .process({
+            let runtime = Arc::clone(&runtime);
+            let queue = Arc::clone(&queue);
+            move |stream, user_data| {
+                let Ok(mut state) = runtime.lock() else {
+                    return;
+                };
+                if !state.active {
+                    return;
+                }
+
+                let Some(mut buffer) = stream.dequeue_buffer() else {
+                    return;
+                };
+                let datas = buffer.datas_mut();
+                if datas.is_empty() {
+                    return;
+                }
+
+                let data = &mut datas[0];
+                let chunk = data.chunk();
+                let offset = chunk.offset() as usize;
+                let chunk_size = chunk.size() as usize;
+                let Some(raw) = data.data() else {
+                    return;
+                };
+                if offset
+                    .checked_add(chunk_size)
+                    .is_none_or(|end| end > raw.len())
+                {
+                    return;
+                }
+
+                let rate = user_data.format.rate();
+                let channels = user_data.format.channels();
+                if rate == 0 || channels == 0 {
+                    return;
+                }
+
+                let frame = AudioFrame {
+                    // TODO: plumb PipeWire timing metadata, same as the video path.
+                    stream_time_ns: 0,
+                    sequence: state.sequence,
+                    sample_rate: rate,
+                    channels: channels as u16,
+                    sample_format: SampleFormat::F32,
+                    data: AudioData::Interleaved(raw[offset..offset + chunk_size].to_vec()),
+                };
+                state.sequence += 1;
+
+                if let Ok(mut queue) = queue.lock() {
+                    if queue.len() >= MAX_QUEUED_FRAMES {
+                        queue.pop_front();
+                    }
+                    queue.push_back(frame);
+                }
+            }
+        })
+        .register()
+        .map_err(platform_error)?;
+    let _listener: StreamListener<UserData> = listener;
+
+    // Offer F32 and let PipeWire pick the graph's native rate and channel
+    // count (parsed back in param_changed).
+    let mut audio_info = AudioInfoRaw::new();
+    audio_info.set_format(AudioFormat::F32LE);
+    let format_obj = pw::spa::pod::Object {
+        type_: SpaTypes::ObjectParamFormat.as_raw(),
+        id: ParamType::EnumFormat.as_raw(),
+        properties: audio_info.into(),
+    };
+    let format_bytes = pw::spa::pod::serialize::PodSerializer::serialize(
+        std::io::Cursor::new(Vec::new()),
+        &pw::spa::pod::Value::Object(format_obj),
+    )
+    .map_err(platform_error)?
+    .0
+    .into_inner();
+
+    let mut params = [Pod::from_bytes(&format_bytes)
+        .ok_or_else(|| PinrayError::Platform("failed to build audio format pod".into()))?];
+    stream
+        .connect(
+            Direction::Input,
+            None,
+            StreamFlags::AUTOCONNECT | StreamFlags::MAP_BUFFERS | StreamFlags::RT_PROCESS,
+            &mut params,
+        )
+        .map_err(platform_error)?;
+
+    let pw_loop = main_loop.loop_();
+    let mut terminate = false;
+    while !terminate {
+        while let Ok(message) = control_rx.try_recv() {
+            match message {
+                ControlMessage::Start => {
+                    if let Ok(mut state) = runtime.lock() {
+                        state.active = true;
+                    }
+                }
+                ControlMessage::Stop => {
+                    if let Ok(mut state) = runtime.lock() {
+                        state.active = false;
+                    }
+                }
+                ControlMessage::Terminate => terminate = true,
+            }
+        }
+
+        if let Ok(mut queue) = queue.lock() {
+            while let Some(frame) = queue.pop_front() {
+                if event_tx.send(frame).is_err() {
+                    return Ok(());
+                }
+            }
+        }
+
+        pw_loop.iterate(pw::loop_::Timeout::Finite(Duration::from_millis(10)));
+    }
+
+    Ok(())
+}
+
+fn platform_error(error: impl std::fmt::Display) -> PinrayError {
+    PinrayError::Platform(error.to_string())
+}

--- a/crates/platform-linux/src/lib.rs
+++ b/crates/platform-linux/src/lib.rs
@@ -1,3 +1,4 @@
+mod audio;
 mod portal;
 mod wayland;
 
@@ -14,6 +15,12 @@ pub fn available_backends() -> Vec<BackendInfo> {
                 supports_audio: false,
                 zero_copy: false,
                 notes: "Wayland portal + PipeWire video backend",
+            },
+            BackendInfo {
+                kind: BackendKind::LinuxPipeWireAudio,
+                supports_audio: true,
+                zero_copy: false,
+                notes: "PipeWire system-mix capture via default sink monitor",
             },
             BackendInfo {
                 kind: BackendKind::LinuxX11,
@@ -48,6 +55,12 @@ pub fn try_resolve(config: &SessionConfig) -> Result<Option<BackendBundle>> {
     }
 
     if wayland::is_wayland_session() {
+        return wayland::resolve_wayland_backend(config).map(Some);
+    }
+
+    // PipeWire audio does not depend on the session type; audio-only
+    // sessions work on X11 too.
+    if config.video_target.is_none() && config.audio_capture.is_some() {
         return wayland::resolve_wayland_backend(config).map(Some);
     }
 

--- a/crates/platform-linux/src/wayland.rs
+++ b/crates/platform-linux/src/wayland.rs
@@ -23,11 +23,12 @@ use pipewire::{
 };
 
 use pinray_core::{
-    BackendBundle, BackendInfo, BackendKind, CaptureEvent, ColorSpace, CursorMode, FrameData::Host,
-    PinrayError, PixelFormat, Result, SessionConfig, VideoBackend, VideoFrame,
+    AudioBackend, AudioCapture, BackendBundle, BackendInfo, BackendKind, CaptureEvent, ColorSpace,
+    CursorMode, FrameData::Host, PinrayError, PixelFormat, Result, SessionConfig, VideoBackend,
+    VideoFrame,
 };
 
-use crate::portal::PortalClient;
+use crate::{audio::PipeWireAudioBackend, portal::PortalClient};
 
 /// Returns `true` if the current session is a Wayland session.
 ///
@@ -39,26 +40,44 @@ pub fn is_wayland_session() -> bool {
         || std::env::var_os("WAYLAND_DISPLAY").is_some()
 }
 
-/// Resolves the Wayland video backend for the given session configuration.
+/// Resolves the Wayland video and/or PipeWire audio backends for the given
+/// session configuration.
 ///
-/// Returns `Unsupported` if audio capture is requested (not yet implemented).
-/// The caller should use `BackendPreference::LinuxX11` as a fallback for audio.
+/// System audio is captured natively from the default sink monitor and does
+/// not need a portal round-trip, so audio-only sessions skip the portal
+/// dialog entirely.
 pub fn resolve_wayland_backend(config: &SessionConfig) -> Result<BackendBundle> {
-    if config.audio_capture.is_some() {
-        // TODO: implement PipeWire system-audio capture against the stable
-        // registry APIs. Keep this explicit instead of introducing a shell-based fallback.
-        return Err(PinrayError::Unsupported(
-            "linux wayland audio capture is not implemented yet; we have video capture only".into(),
-        ));
-    }
+    let audio: Option<Box<dyn AudioBackend>> = match &config.audio_capture {
+        None => None,
+        Some(AudioCapture::SystemMix) => Some(Box::new(PipeWireAudioBackend::new()?)),
+        Some(AudioCapture::Microphone(_)) => {
+            return Err(PinrayError::Unsupported(
+                "linux microphone capture is not implemented yet".into(),
+            ));
+        }
+    };
 
-    let backend = WaylandVideoBackend::new(config.clone())?;
-    let info = backend.info();
-    Ok(BackendBundle {
-        info,
-        video: Some(Box::new(backend)),
-        audio: None,
-    })
+    let video: Option<Box<dyn VideoBackend>> = if config.video_target.is_some() {
+        Some(Box::new(WaylandVideoBackend::new(config.clone())?))
+    } else {
+        None
+    };
+
+    let info = match (&video, &audio) {
+        (Some(video), _) => {
+            let mut info = video.info();
+            info.supports_audio = audio.is_some();
+            info
+        }
+        (None, Some(audio)) => audio.info(),
+        (None, None) => {
+            return Err(PinrayError::InvalidConfig(
+                "at least one of video_target or audio_capture must be set".into(),
+            ));
+        }
+    };
+
+    Ok(BackendBundle { info, video, audio })
 }
 
 struct WaylandVideoBackend {
@@ -119,7 +138,7 @@ impl WaylandVideoBackend {
                 kind: BackendKind::LinuxWaylandPortal,
                 supports_audio: false,
                 zero_copy: false,
-                notes: "Wayland video via XDG Desktop Portal + PipeWire 0.9",
+                notes: "Wayland video via XDG Desktop Portal + PipeWire",
             },
             control_tx,
             event_rx,
@@ -504,7 +523,16 @@ fn normalize_frame(
     desired_format: PixelFormat,
 ) -> (PixelFormat, Vec<u8>) {
     match (source_format, desired_format) {
-        (VideoFormat::BGRx, PixelFormat::Bgra8888) => (PixelFormat::Bgra8888, raw.to_vec()),
+        (VideoFormat::BGRA | VideoFormat::BGRx, PixelFormat::Bgra8888) => {
+            (PixelFormat::Bgra8888, raw.to_vec())
+        }
+        (VideoFormat::BGRA, PixelFormat::Rgba8888) => {
+            let mut data = raw.to_vec();
+            for pixel in data.chunks_exact_mut(4) {
+                pixel.swap(0, 2);
+            }
+            (PixelFormat::Rgba8888, data)
+        }
         (VideoFormat::RGBx, PixelFormat::Rgba8888) => (PixelFormat::Rgba8888, raw.to_vec()),
         (VideoFormat::RGBA, PixelFormat::Rgba8888) => (PixelFormat::Rgba8888, raw.to_vec()),
         (VideoFormat::RGB, PixelFormat::Rgb888) => (PixelFormat::Rgb888, raw.to_vec()),

--- a/crates/platform-macos/src/capture.rs
+++ b/crates/platform-macos/src/capture.rs
@@ -40,13 +40,18 @@ use crate::content::get_shareable_content;
 enum RawEvent {
     Video(VideoFrame),
     Audio(AudioFrame),
+    /// Stream stopped on its own (error or system action); carries the message.
+    Ended(String),
 }
 
 //  SCStreamOutput delegate
 struct OutputIvars {
     event_tx: mpsc::SyncSender<RawEvent>,
     active: Arc<AtomicBool>,
-    sequence: Arc<AtomicU64>,
+    // Separate per-stream counters, advanced only when a frame is actually
+    // delivered, so consumers can detect drops per stream.
+    video_sequence: AtomicU64,
+    audio_sequence: AtomicU64,
     desired_pixel_format: PixelFormat,
     capture_audio: bool,
 }
@@ -71,19 +76,25 @@ define_class!(
             if !ivars.active.load(Ordering::Acquire) {
                 return;
             }
-            let seq = ivars.sequence.fetch_add(1, Ordering::Relaxed);
 
+            // This callback runs on one serial GCD queue, so the
+            // load-then-store on the sequence counters is race-free.
             match output_type {
                 SCStreamOutputType::Screen => {
+                    let seq = ivars.video_sequence.load(Ordering::Relaxed);
                     if let Some(frame) =
                         extract_video_frame(sample_buffer, seq, ivars.desired_pixel_format)
+                        && ivars.event_tx.try_send(RawEvent::Video(frame)).is_ok()
                     {
-                        let _ = ivars.event_tx.try_send(RawEvent::Video(frame));
+                        ivars.video_sequence.store(seq + 1, Ordering::Relaxed);
                     }
                 }
                 SCStreamOutputType::Audio if ivars.capture_audio => {
-                    if let Some(frame) = extract_audio_frame(sample_buffer, seq) {
-                        let _ = ivars.event_tx.try_send(RawEvent::Audio(frame));
+                    let seq = ivars.audio_sequence.load(Ordering::Relaxed);
+                    if let Some(frame) = extract_audio_frame(sample_buffer, seq)
+                        && ivars.event_tx.try_send(RawEvent::Audio(frame)).is_ok()
+                    {
+                        ivars.audio_sequence.store(seq + 1, Ordering::Relaxed);
                     }
                 }
                 _ => {}
@@ -96,14 +107,14 @@ impl SckOutput {
     fn new(
         event_tx: mpsc::SyncSender<RawEvent>,
         active: Arc<AtomicBool>,
-        sequence: Arc<AtomicU64>,
         desired_pixel_format: PixelFormat,
         capture_audio: bool,
     ) -> Retained<Self> {
         let this = Self::alloc().set_ivars(OutputIvars {
             event_tx,
             active,
-            sequence,
+            video_sequence: AtomicU64::new(0),
+            audio_sequence: AtomicU64::new(0),
             desired_pixel_format,
             capture_audio,
         });
@@ -114,6 +125,7 @@ impl SckOutput {
 //  SCStreamDelegate
 struct DelegateIvars {
     errored: Arc<AtomicBool>,
+    event_tx: mpsc::SyncSender<RawEvent>,
 }
 
 define_class!(
@@ -130,13 +142,20 @@ define_class!(
             let desc = error.localizedDescription();
             tracing::error!(%desc, "SCStream stopped unexpectedly");
             self.ivars().errored.store(true, Ordering::Release);
+            // Wake a caller blocked in next_event(None). If the channel is
+            // full the receiver is not blocked and the errored flag catches
+            // it on the next call instead.
+            let _ = self
+                .ivars()
+                .event_tx
+                .try_send(RawEvent::Ended(desc.to_string()));
         }
     }
 );
 
 impl SckDelegate {
-    fn new(errored: Arc<AtomicBool>) -> Retained<Self> {
-        let this = Self::alloc().set_ivars(DelegateIvars { errored });
+    fn new(errored: Arc<AtomicBool>, event_tx: mpsc::SyncSender<RawEvent>) -> Retained<Self> {
+        let this = Self::alloc().set_ivars(DelegateIvars { errored, event_tx });
         unsafe { msg_send![super(this), init] }
     }
 }
@@ -179,14 +198,19 @@ impl VideoBackend for MacVideoBackend {
             cv2.notify_one();
         });
 
+        // Set active before starting so frames delivered between the
+        // completion handler firing and our return are not discarded.
+        self.active.store(true, Ordering::Release);
         unsafe { self.stream.startCaptureWithCompletionHandler(Some(&block)) };
 
         let mut guard = cv
             .wait_while(result.lock().unwrap(), |v| v.is_none())
             .unwrap();
-        guard.take().unwrap()?;
+        if let Err(error) = guard.take().unwrap() {
+            self.active.store(false, Ordering::Release);
+            return Err(error);
+        }
 
-        self.active.store(true, Ordering::Release);
         tracing::debug!("SCStream started");
         Ok(())
     }
@@ -237,17 +261,28 @@ impl VideoBackend for MacVideoBackend {
                 .recv()
                 .map_err(|_| PinrayError::Platform("SCStream event channel disconnected".into()))?,
         };
-        Ok(match raw {
-            RawEvent::Video(f) => CaptureEvent::Video(f),
-            RawEvent::Audio(f) => CaptureEvent::Audio(f),
-        })
+        match raw {
+            RawEvent::Video(f) => Ok(CaptureEvent::Video(f)),
+            RawEvent::Audio(f) => Ok(CaptureEvent::Audio(f)),
+            RawEvent::Ended(msg) => Err(PinrayError::Platform(format!(
+                "SCStream stopped with error: {msg}"
+            ))),
+        }
     }
 }
 
 // ─── public constructor ───────────────────────────────────────────────────────
 
 pub fn build_backend(config: &SessionConfig) -> Result<BackendBundle> {
-    let supports_audio = config.audio_capture.is_some();
+    let supports_audio = match &config.audio_capture {
+        None => false,
+        Some(pinray_core::AudioCapture::SystemMix) => true,
+        Some(pinray_core::AudioCapture::Microphone(_)) => {
+            return Err(PinrayError::Unsupported(
+                "macos microphone capture is not implemented yet".into(),
+            ));
+        }
+    };
     let content = get_shareable_content()?;
 
     let filter = build_content_filter(&content, config)?;
@@ -257,16 +292,14 @@ pub fn build_backend(config: &SessionConfig) -> Result<BackendBundle> {
 
     let active = Arc::new(AtomicBool::new(false));
     let errored = Arc::new(AtomicBool::new(false));
-    let sequence = Arc::new(AtomicU64::new(0));
 
     let output = SckOutput::new(
-        event_tx,
+        event_tx.clone(),
         Arc::clone(&active),
-        Arc::clone(&sequence),
         config.pixel_format,
         supports_audio,
     );
-    let delegate = SckDelegate::new(Arc::clone(&errored));
+    let delegate = SckDelegate::new(Arc::clone(&errored), event_tx);
 
     let delegate_obj = ProtocolObject::<dyn SCStreamDelegate>::from_ref::<SckDelegate>(&*delegate);
 
@@ -424,11 +457,10 @@ fn build_stream_configuration(
         cfg.setHeight(out_h as usize);
     }
 
-    let cv_fmt = match config.pixel_format {
-        PixelFormat::Rgba8888 => kCVPixelFormatType_32RGBA,
-        _ => kCVPixelFormatType_32BGRA,
-    };
-    unsafe { cfg.setPixelFormat(cv_fmt) };
+    // SCKit only accepts BGRA (plus l10r/420v/420f/...); RGBA is not a valid
+    // stream format. Always capture BGRA — normalize_pixels swizzles to RGBA
+    // when the caller asked for it.
+    unsafe { cfg.setPixelFormat(kCVPixelFormatType_32BGRA) };
 
     unsafe { cfg.setShowsCursor(matches!(config.cursor_mode, CursorMode::Embedded)) };
 
@@ -498,11 +530,10 @@ fn display_dimensions(content: &SCShareableContent, config: &SessionConfig) -> (
 // ─── frame extraction ─────────────────────────────────────────────────────────
 
 fn pts_to_ns(pts: objc2_core_media::CMTime) -> i64 {
+    // Widen to i128: SCKit uses host-clock timescales (1e9), so
+    // value * 1e9 overflows i64 within seconds of uptime.
     if pts.timescale != 0 {
-        pts.value
-            .saturating_mul(1_000_000_000)
-            .checked_div(pts.timescale as i64)
-            .unwrap_or(0)
+        (pts.value as i128 * 1_000_000_000 / pts.timescale as i128) as i64
     } else {
         0
     }
@@ -539,7 +570,8 @@ fn extract_video_frame(
             sequence,
             width: w,
             height: h,
-            stride: bpr,
+            // copy_rows strips CVPixelBuffer row padding, so rows are packed.
+            stride: w * 4,
             pixel_format,
             color_space: Some(ColorSpace::Srgb),
             data: FrameData::Host(data),

--- a/crates/platform-windows/Cargo.toml
+++ b/crates/platform-windows/Cargo.toml
@@ -9,3 +9,29 @@ repository.workspace = true
 [dependencies]
 pinray-core = { path = "../core", version = "0.1" }
 tracing.workspace = true
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.62", features = [
+    "Foundation",
+    "Graphics_Capture",
+    "Graphics_DirectX_Direct3D11",
+    "Win32_Foundation",
+    "Win32_Graphics_Direct3D",
+    "Win32_Graphics_Direct3D11",
+    "Win32_Graphics_Dwm",
+    "Win32_Graphics_Dxgi",
+    "Win32_Graphics_Dxgi_Common",
+    "Win32_Graphics_Gdi",
+    "Win32_Media_Audio",
+    "Win32_Media_KernelStreaming",
+    "Win32_Media_Multimedia",
+    "Win32_System_Com",
+    "Win32_System_Com_StructuredStorage",
+    "Win32_System_Performance",
+    "Win32_System_Threading",
+    "Win32_System_Variant",
+    "Win32_System_WinRT_Direct3D11",
+    "Win32_System_WinRT_Graphics_Capture",
+    "Win32_UI_HiDpi",
+    "Win32_UI_WindowsAndMessaging",
+] }

--- a/crates/platform-windows/src/d3d.rs
+++ b/crates/platform-windows/src/d3d.rs
@@ -1,0 +1,170 @@
+//! Shared Direct3D 11 helpers: device creation, staging copy to host memory,
+//! and QPC timestamp normalization. Used by both the DXGI and WGC backends.
+
+use pinray_core::{PinrayError, PixelFormat, Rect, Result};
+use windows::Win32::Foundation::HMODULE;
+use windows::Win32::Graphics::Direct3D::{D3D_DRIVER_TYPE, D3D_DRIVER_TYPE_HARDWARE, D3D_DRIVER_TYPE_UNKNOWN};
+use windows::Win32::Graphics::Direct3D11::{
+    D3D11_BOX, D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_MAP_READ,
+    D3D11_MAPPED_SUBRESOURCE, D3D11_SDK_VERSION, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING,
+    D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, ID3D11Resource, ID3D11Texture2D,
+};
+use windows::Win32::Graphics::Dxgi::IDXGIAdapter;
+use windows::Win32::System::Performance::QueryPerformanceFrequency;
+use windows::core::Interface;
+
+pub(crate) fn win_err(context: &str, error: windows::core::Error) -> PinrayError {
+    PinrayError::Platform(format!("{context}: {error}"))
+}
+
+/// Creates a D3D11 device, either on a specific DXGI adapter (required by
+/// DXGI desktop duplication, which fails cross-adapter) or on the default
+/// hardware adapter.
+pub(crate) fn create_d3d_device(
+    adapter: Option<&IDXGIAdapter>,
+) -> Result<(ID3D11Device, ID3D11DeviceContext)> {
+    let driver_type: D3D_DRIVER_TYPE = if adapter.is_some() {
+        D3D_DRIVER_TYPE_UNKNOWN
+    } else {
+        D3D_DRIVER_TYPE_HARDWARE
+    };
+
+    let mut device = None;
+    unsafe {
+        D3D11CreateDevice(
+            adapter,
+            driver_type,
+            HMODULE::default(),
+            D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+            None,
+            D3D11_SDK_VERSION,
+            Some(&mut device),
+            None,
+            None,
+        )
+        .map_err(|e| win_err("D3D11CreateDevice", e))?;
+    }
+
+    let device = device.ok_or_else(|| PinrayError::Platform("D3D11CreateDevice returned no device".into()))?;
+    let context = unsafe { device.GetImmediateContext() }
+        .map_err(|e| win_err("GetImmediateContext", e))?;
+    Ok((device, context))
+}
+
+pub(crate) fn qpc_frequency() -> Result<i64> {
+    let mut freq = 0i64;
+    unsafe { QueryPerformanceFrequency(&mut freq) }
+        .map_err(|e| win_err("QueryPerformanceFrequency", e))?;
+    Ok(freq)
+}
+
+/// Converts a raw QPC counter value to nanoseconds since boot.
+pub(crate) fn qpc_to_ns(qpc: i64, freq: i64) -> i64 {
+    (qpc as i128 * 1_000_000_000 / freq as i128) as i64
+}
+
+pub(crate) struct HostCopy {
+    pub data: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub stride: u32,
+}
+
+/// Copies a GPU texture (assumed BGRA8) into host memory via a staging
+/// texture, applying an optional crop and an optional BGRA→RGBA swizzle.
+pub(crate) fn texture_to_host(
+    device: &ID3D11Device,
+    context: &ID3D11DeviceContext,
+    source: &ID3D11Texture2D,
+    crop: Option<Rect>,
+    pixel_format: PixelFormat,
+) -> Result<HostCopy> {
+    unsafe {
+        let mut src_desc = D3D11_TEXTURE2D_DESC::default();
+        source.GetDesc(&mut src_desc);
+
+        let (x, y, width, height) = match crop {
+            Some(rect) => (rect.x.max(0) as u32, rect.y.max(0) as u32, rect.width, rect.height),
+            None => (0, 0, src_desc.Width, src_desc.Height),
+        };
+        if x + width > src_desc.Width || y + height > src_desc.Height {
+            return Err(PinrayError::InvalidConfig(format!(
+                "crop_rect {x},{y} {width}x{height} exceeds source {}x{}",
+                src_desc.Width, src_desc.Height
+            )));
+        }
+
+        let staging = {
+            let mut desc = src_desc;
+            desc.Width = width;
+            desc.Height = height;
+            desc.MipLevels = 1;
+            desc.ArraySize = 1;
+            desc.SampleDesc.Count = 1;
+            desc.SampleDesc.Quality = 0;
+            desc.BindFlags = 0;
+            desc.MiscFlags = 0;
+            desc.Usage = D3D11_USAGE_STAGING;
+            desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ.0 as u32;
+
+            let mut staging = None;
+            device
+                .CreateTexture2D(&desc, None, Some(&mut staging))
+                .map_err(|e| win_err("CreateTexture2D(staging)", e))?;
+            staging.ok_or_else(|| PinrayError::Platform("CreateTexture2D returned no texture".into()))?
+        };
+
+        let region = D3D11_BOX {
+            left: x,
+            top: y,
+            right: x + width,
+            bottom: y + height,
+            front: 0,
+            back: 1,
+        };
+        let staging_resource: ID3D11Resource =
+            staging.cast().map_err(|e| win_err("staging cast", e))?;
+        let source_resource: ID3D11Resource =
+            source.cast().map_err(|e| win_err("source cast", e))?;
+        context.CopySubresourceRegion(
+            Some(&staging_resource),
+            0,
+            0,
+            0,
+            0,
+            Some(&source_resource),
+            0,
+            Some(&region),
+        );
+
+        let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+        context
+            .Map(Some(&staging_resource), 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+            .map_err(|e| win_err("Map(staging)", e))?;
+
+        let row_bytes = (width * 4) as usize;
+        let mut data = vec![0u8; row_bytes * height as usize];
+        let src_ptr = mapped.pData as *const u8;
+        for row in 0..height as usize {
+            let src = std::slice::from_raw_parts(
+                src_ptr.add(row * mapped.RowPitch as usize),
+                row_bytes,
+            );
+            data[row * row_bytes..(row + 1) * row_bytes].copy_from_slice(src);
+        }
+        context.Unmap(Some(&staging_resource), 0);
+
+        if pixel_format == PixelFormat::Rgba8888 {
+            for px in data.chunks_exact_mut(4) {
+                px.swap(0, 2);
+            }
+        }
+
+        Ok(HostCopy {
+            data,
+            width,
+            height,
+            stride: width * 4,
+        })
+    }
+}

--- a/crates/platform-windows/src/dxgi.rs
+++ b/crates/platform-windows/src/dxgi.rs
@@ -1,0 +1,184 @@
+//! DXGI Desktop Duplication video backend.
+//!
+//! Pull-model: `next_event` maps directly onto `AcquireNextFrame`, so no
+//! capture thread is needed. Frames are only delivered when the desktop
+//! changes; an unchanged desktop surfaces as `PinrayError::Timeout`.
+//!
+//! Known limitation: duplication does not composite the mouse cursor into
+//! the frame (cursor arrives as separate metadata, which we do not yet
+//! draw). Use the WGC backend when an embedded cursor is required.
+
+use std::time::{Duration, Instant};
+
+use pinray_core::{
+    BackendInfo, BackendKind, CaptureEvent, FrameData, GapEvent, GapReason, PinrayError,
+    PixelFormat, Rect, Result, SessionConfig, VideoBackend, VideoFrame,
+};
+use tracing::{debug, warn};
+use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D};
+use windows::Win32::Graphics::Dxgi::{
+    DXGI_ERROR_ACCESS_LOST, DXGI_ERROR_WAIT_TIMEOUT, DXGI_OUTDUPL_FRAME_INFO, IDXGIOutput1,
+    IDXGIOutputDuplication, IDXGIResource,
+};
+use windows::core::Interface;
+
+use crate::d3d::{create_d3d_device, qpc_frequency, qpc_to_ns, texture_to_host, win_err};
+use crate::enumerate::DisplayEntry;
+
+pub(crate) struct DxgiVideoBackend {
+    device: ID3D11Device,
+    context: ID3D11DeviceContext,
+    output: IDXGIOutput1,
+    duplication: Option<IDXGIOutputDuplication>,
+    pixel_format: PixelFormat,
+    crop: Option<Rect>,
+    sequence: u64,
+    qpc_freq: i64,
+}
+
+impl DxgiVideoBackend {
+    pub(crate) fn new(display: &DisplayEntry, config: &SessionConfig) -> Result<Self> {
+        let (device, context) = create_d3d_device(Some(&display.adapter))?;
+        let output: IDXGIOutput1 = display
+            .output
+            .cast()
+            .map_err(|e| win_err("IDXGIOutput1 cast", e))?;
+
+        // Probe duplication now so that Auto backend selection can fall back
+        // to WGC when duplication is denied (e.g. by session policy).
+        let probe = unsafe { output.DuplicateOutput(&device) }
+            .map_err(|e| PinrayError::BackendUnavailable(format!("DuplicateOutput: {e}")))?;
+        drop(probe);
+
+        Ok(Self {
+            device,
+            context,
+            output,
+            duplication: None,
+            pixel_format: config.pixel_format,
+            crop: config.crop_rect,
+            sequence: 0,
+            qpc_freq: qpc_frequency()?,
+        })
+    }
+
+    pub(crate) fn backend_info() -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::WindowsDxgi,
+            supports_audio: false,
+            zero_copy: false,
+            notes: "DXGI desktop duplication: display capture only, frames on desktop change, cursor not embedded",
+        }
+    }
+
+    fn recreate_duplication(&mut self) -> Result<()> {
+        self.duplication = None;
+        let duplication = unsafe { self.output.DuplicateOutput(&self.device) }
+            .map_err(|e| win_err("DuplicateOutput", e))?;
+        self.duplication = Some(duplication);
+        Ok(())
+    }
+}
+
+impl VideoBackend for DxgiVideoBackend {
+    fn info(&self) -> BackendInfo {
+        Self::backend_info()
+    }
+
+    fn start(&mut self) -> Result<()> {
+        if self.duplication.is_none() {
+            self.recreate_duplication()?;
+            debug!("dxgi duplication started");
+        }
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        self.duplication = None;
+        debug!("dxgi duplication stopped");
+        Ok(())
+    }
+
+    fn next_event(&mut self, timeout: Option<Duration>) -> Result<CaptureEvent> {
+        let deadline = timeout.map(|t| Instant::now() + t);
+
+        loop {
+            let wait_ms = match deadline {
+                Some(deadline) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(PinrayError::Timeout(timeout.unwrap_or_default()));
+                    }
+                    remaining.as_millis().min(u32::MAX as u128) as u32
+                }
+                None => u32::MAX,
+            };
+
+            let duplication = self
+                .duplication
+                .as_ref()
+                .ok_or_else(|| PinrayError::Platform("dxgi backend not started".into()))?
+                .clone();
+
+            let mut frame_info = DXGI_OUTDUPL_FRAME_INFO::default();
+            let mut resource: Option<IDXGIResource> = None;
+            let acquired =
+                unsafe { duplication.AcquireNextFrame(wait_ms, &mut frame_info, &mut resource) };
+
+            if let Err(error) = acquired {
+                if error.code() == DXGI_ERROR_WAIT_TIMEOUT {
+                    return Err(PinrayError::Timeout(timeout.unwrap_or_default()));
+                }
+                if error.code() == DXGI_ERROR_ACCESS_LOST {
+                    // Mode switch, secure desktop, etc. Recreate and report a gap.
+                    warn!("dxgi duplication access lost; recreating");
+                    self.recreate_duplication()?;
+                    return Ok(CaptureEvent::Gap(GapEvent {
+                        stream_time_ns: qpc_to_ns(frame_info.LastPresentTime, self.qpc_freq),
+                        reason: GapReason::BackendRestarted,
+                        dropped_frames: None,
+                    }));
+                }
+                return Err(win_err("AcquireNextFrame", error));
+            }
+
+            // LastPresentTime == 0 means no new image (e.g. only mouse
+            // movement); release and keep waiting.
+            if frame_info.LastPresentTime == 0 {
+                let _ = unsafe { duplication.ReleaseFrame() };
+                continue;
+            }
+
+            let resource =
+                resource.ok_or_else(|| PinrayError::Platform("AcquireNextFrame returned no resource".into()))?;
+            let texture: ID3D11Texture2D = resource
+                .cast()
+                .map_err(|e| win_err("ID3D11Texture2D cast", e))?;
+
+            let copy = texture_to_host(
+                &self.device,
+                &self.context,
+                &texture,
+                self.crop,
+                self.pixel_format,
+            );
+            let _ = unsafe { duplication.ReleaseFrame() };
+            let copy = copy?;
+
+            let sequence = self.sequence;
+            self.sequence += 1;
+
+            return Ok(CaptureEvent::Video(VideoFrame {
+                stream_time_ns: qpc_to_ns(frame_info.LastPresentTime, self.qpc_freq),
+                sequence,
+                width: copy.width,
+                height: copy.height,
+                stride: copy.stride,
+                pixel_format: self.pixel_format,
+                color_space: None,
+                data: FrameData::Host(copy.data),
+                damage: None,
+            }));
+        }
+    }
+}

--- a/crates/platform-windows/src/enumerate.rs
+++ b/crates/platform-windows/src/enumerate.rs
@@ -1,0 +1,203 @@
+//! Display and window enumeration.
+//!
+//! Displays are enumerated through DXGI (adapter → output) so that a display
+//! `SourceId` can later be mapped back to the exact adapter/output pair the
+//! DXGI duplication backend needs. Windows are enumerated with `EnumWindows`.
+
+use pinray_core::{
+    AudioDeviceSource, CaptureSource, DisplaySource, PinrayError, Result, SourceId, WindowSource,
+};
+use windows::Win32::Foundation::{HWND, LPARAM};
+use windows::Win32::Graphics::Dwm::{DWMWA_CLOAKED, DwmGetWindowAttribute};
+use windows::Win32::Graphics::Dxgi::{CreateDXGIFactory1, IDXGIAdapter, IDXGIFactory1, IDXGIOutput};
+use windows::Win32::Graphics::Gdi::HMONITOR;
+use windows::Win32::System::Threading::{
+    OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+};
+use windows::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+use windows::Win32::UI::WindowsAndMessaging::{
+    EnumWindows, GetWindowTextW, GetWindowThreadProcessId, IsWindowVisible,
+};
+use windows::core::{BOOL, PWSTR};
+
+use crate::d3d::win_err;
+
+pub(crate) const SYSTEM_AUDIO_ID: &str = "audio:system-mix";
+
+/// A display plus the DXGI adapter/output coordinates needed to duplicate it.
+pub(crate) struct DisplayEntry {
+    pub source: DisplaySource,
+    pub adapter: IDXGIAdapter,
+    pub output: IDXGIOutput,
+    pub hmonitor: HMONITOR,
+}
+
+fn utf16_to_string(buf: &[u16]) -> String {
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    String::from_utf16_lossy(&buf[..len])
+}
+
+pub(crate) fn enumerate_displays() -> Result<Vec<DisplayEntry>> {
+    let factory: IDXGIFactory1 =
+        unsafe { CreateDXGIFactory1() }.map_err(|e| win_err("CreateDXGIFactory1", e))?;
+
+    let mut entries = Vec::new();
+    let mut adapter_index = 0u32;
+    loop {
+        let adapter: IDXGIAdapter = match unsafe { factory.EnumAdapters(adapter_index) } {
+            Ok(adapter) => adapter,
+            Err(_) => break,
+        };
+        adapter_index += 1;
+
+        let mut output_index = 0u32;
+        loop {
+            let output = match unsafe { adapter.EnumOutputs(output_index) } {
+                Ok(output) => output,
+                Err(_) => break,
+            };
+            output_index += 1;
+
+            let desc = match unsafe { output.GetDesc() } {
+                Ok(desc) => desc,
+                Err(_) => continue,
+            };
+            if !desc.AttachedToDesktop.as_bool() {
+                continue;
+            }
+
+            let name = utf16_to_string(&desc.DeviceName);
+            let coords = desc.DesktopCoordinates;
+            let width = (coords.right - coords.left).max(0) as u32;
+            let height = (coords.bottom - coords.top).max(0) as u32;
+
+            let mut dpi_x = 96u32;
+            let mut dpi_y = 96u32;
+            let _ = unsafe { GetDpiForMonitor(desc.Monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) };
+
+            entries.push(DisplayEntry {
+                source: DisplaySource {
+                    id: SourceId::new(format!("display:{name}")),
+                    name,
+                    width,
+                    height,
+                    scale_factor_milli: dpi_x * 1000 / 96,
+                    is_primary: coords.left == 0 && coords.top == 0,
+                },
+                adapter: adapter.clone(),
+                output,
+                hmonitor: desc.Monitor,
+            });
+        }
+    }
+
+    Ok(entries)
+}
+
+/// Resolves a display `SourceId` (or `"auto"` for the primary display).
+pub(crate) fn find_display(id: &SourceId) -> Result<DisplayEntry> {
+    let mut entries = enumerate_displays()?;
+    if entries.is_empty() {
+        return Err(PinrayError::BackendUnavailable("no displays found".into()));
+    }
+
+    if id.0 == "auto" {
+        let primary = entries.iter().position(|e| e.source.is_primary).unwrap_or(0);
+        return Ok(entries.swap_remove(primary));
+    }
+
+    entries
+        .into_iter()
+        .find(|e| e.source.id == *id)
+        .ok_or_else(|| PinrayError::InvalidConfig(format!("display source not found: {}", id.0)))
+}
+
+/// Parses a window `SourceId` of the form `window:<hwnd>` back into an HWND.
+pub(crate) fn find_window(id: &SourceId) -> Result<HWND> {
+    let raw = id
+        .0
+        .strip_prefix("window:")
+        .and_then(|v| v.parse::<isize>().ok())
+        .ok_or_else(|| {
+            PinrayError::InvalidConfig(format!("invalid window source id: {}", id.0))
+        })?;
+    Ok(HWND(raw as *mut core::ffi::c_void))
+}
+
+fn is_cloaked(hwnd: HWND) -> bool {
+    let mut cloaked = 0u32;
+    unsafe {
+        DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_CLOAKED,
+            &mut cloaked as *mut u32 as *mut core::ffi::c_void,
+            std::mem::size_of::<u32>() as u32,
+        )
+    }
+    .map(|_| cloaked != 0)
+    .unwrap_or(false)
+}
+
+fn process_image_name(hwnd: HWND) -> Option<String> {
+    let mut pid = 0u32;
+    unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
+    if pid == 0 {
+        return None;
+    }
+
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }.ok()?;
+    let mut buf = vec![0u16; 1024];
+    let mut len = buf.len() as u32;
+    let result = unsafe {
+        QueryFullProcessImageNameW(process, PROCESS_NAME_WIN32, PWSTR(buf.as_mut_ptr()), &mut len)
+    };
+    let _ = unsafe { windows::Win32::Foundation::CloseHandle(process) };
+    result.ok()?;
+
+    let path = String::from_utf16_lossy(&buf[..len as usize]);
+    path.rsplit('\\').next().map(|s| s.to_string())
+}
+
+pub(crate) fn enumerate_windows() -> Result<Vec<WindowSource>> {
+    unsafe extern "system" fn callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let windows = unsafe { &mut *(lparam.0 as *mut Vec<WindowSource>) };
+
+        if !unsafe { IsWindowVisible(hwnd) }.as_bool() || is_cloaked(hwnd) {
+            return BOOL(1);
+        }
+
+        let mut title_buf = [0u16; 512];
+        let title_len = unsafe { GetWindowTextW(hwnd, &mut title_buf) };
+        if title_len <= 0 {
+            return BOOL(1);
+        }
+
+        windows.push(WindowSource {
+            id: SourceId::new(format!("window:{}", hwnd.0 as isize)),
+            title: String::from_utf16_lossy(&title_buf[..title_len as usize]),
+            app_name: process_image_name(hwnd),
+        });
+        BOOL(1)
+    }
+
+    let mut windows: Vec<WindowSource> = Vec::new();
+    unsafe { EnumWindows(Some(callback), LPARAM(&mut windows as *mut _ as isize)) }
+        .map_err(|e| win_err("EnumWindows", e))?;
+    Ok(windows)
+}
+
+pub(crate) fn enumerate_all() -> Result<Vec<CaptureSource>> {
+    let mut sources = Vec::new();
+    for entry in enumerate_displays()? {
+        sources.push(CaptureSource::Display(entry.source));
+    }
+    for window in enumerate_windows()? {
+        sources.push(CaptureSource::Window(window));
+    }
+    sources.push(CaptureSource::SystemAudio(AudioDeviceSource {
+        id: SourceId::new(SYSTEM_AUDIO_ID),
+        name: "System audio (WASAPI loopback)".into(),
+        is_default: true,
+    }));
+    Ok(sources)
+}

--- a/crates/platform-windows/src/lib.rs
+++ b/crates/platform-windows/src/lib.rs
@@ -1,48 +1,154 @@
-use pinray_core::{
-    BackendBundle, BackendInfo, BackendKind, BackendPreference, CaptureSource, PinrayError, Result,
-    SessionConfig,
-};
+//! Windows capture backends: DXGI desktop duplication, Windows Graphics
+//! Capture (WGC), and WASAPI loopback audio.
+//!
+//! Backend selection policy (see `docs/windows.md`):
+//! - Display target + `Auto`: DXGI first, WGC as fallback.
+//! - Window target + `Auto`: WGC (DXGI cannot capture single windows).
+//! - Explicit `WindowsDxgi` / `WindowsWgc` preferences are honored as-is.
+//! - `AudioCapture::SystemMix` pairs a WASAPI loopback backend with either
+//!   video backend, or runs standalone for audio-only sessions.
+
+#[cfg(target_os = "windows")]
+mod d3d;
+#[cfg(target_os = "windows")]
+mod dxgi;
+#[cfg(target_os = "windows")]
+mod enumerate;
+#[cfg(target_os = "windows")]
+mod wasapi;
+#[cfg(target_os = "windows")]
+mod wgc;
+
+use pinray_core::{BackendBundle, BackendInfo, BackendPreference, CaptureSource, Result, SessionConfig};
 
 pub fn available_backends() -> Vec<BackendInfo> {
-    if cfg!(target_os = "windows") {
+    #[cfg(target_os = "windows")]
+    {
         vec![
-            BackendInfo {
-                kind: BackendKind::WindowsDxgi,
-                supports_audio: true,
-                zero_copy: true,
-                notes: "DXGI backend not implemented yet",
-            },
-            BackendInfo {
-                kind: BackendKind::WindowsWgc,
-                supports_audio: true,
-                zero_copy: true,
-                notes: "WGC backend not implemented yet",
-            },
+            dxgi::DxgiVideoBackend::backend_info(),
+            wgc::WgcVideoBackend::backend_info(),
+            wasapi::WasapiAudioBackend::backend_info(),
         ]
-    } else {
-        Vec::new()
     }
+
+    #[cfg(not(target_os = "windows"))]
+    Vec::new()
 }
 
 pub fn enumerate_sources() -> Result<Vec<CaptureSource>> {
+    #[cfg(target_os = "windows")]
+    {
+        enumerate::enumerate_all()
+    }
+
+    #[cfg(not(target_os = "windows"))]
     Ok(Vec::new())
 }
 
 pub fn try_resolve(config: &SessionConfig) -> Result<Option<BackendBundle>> {
-    if !cfg!(target_os = "windows") {
-        return Ok(None);
-    }
-
     let applies = matches!(
         config.backend_preference,
         BackendPreference::Auto | BackendPreference::WindowsDxgi | BackendPreference::WindowsWgc
     );
-
-    if !applies {
+    if !cfg!(target_os = "windows") || !applies {
         return Ok(None);
     }
 
-    Err(PinrayError::BackendUnavailable(
-        "windows backend scaffolding exists, but will work on DXGI/WGC implementation later".into(),
-    ))
+    #[cfg(target_os = "windows")]
+    {
+        resolve(config).map(Some)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    unreachable!()
+}
+
+#[cfg(target_os = "windows")]
+fn resolve(config: &SessionConfig) -> Result<BackendBundle> {
+    use pinray_core::{
+        AudioBackend, AudioCapture, PinrayError, PixelFormat, VideoBackend, VideoCaptureTarget,
+    };
+    use tracing::warn;
+
+    if !matches!(
+        config.pixel_format,
+        PixelFormat::Bgra8888 | PixelFormat::Rgba8888
+    ) {
+        return Err(PinrayError::Unsupported(format!(
+            "windows backends support Bgra8888 and Rgba8888 only, got {:?}",
+            config.pixel_format
+        )));
+    }
+    if let Some(rect) = config.crop_rect
+        && (rect.x < 0 || rect.y < 0)
+    {
+        return Err(PinrayError::InvalidConfig(
+            "crop_rect x and y must be non-negative on windows backends".into(),
+        ));
+    }
+
+    let video: Option<Box<dyn VideoBackend>> = match &config.video_target {
+        None => None,
+        Some(VideoCaptureTarget::Display(id)) => {
+            let display = enumerate::find_display(id)?;
+            match config.backend_preference {
+                BackendPreference::WindowsWgc => Some(Box::new(wgc::WgcVideoBackend::new(
+                    wgc::WgcTarget::Monitor(display.hmonitor),
+                    config,
+                )?)),
+                BackendPreference::WindowsDxgi => {
+                    Some(Box::new(dxgi::DxgiVideoBackend::new(&display, config)?))
+                }
+                _ => match dxgi::DxgiVideoBackend::new(&display, config) {
+                    Ok(backend) => Some(Box::new(backend)),
+                    Err(error) => {
+                        warn!("dxgi unavailable ({error}); falling back to wgc");
+                        Some(Box::new(wgc::WgcVideoBackend::new(
+                            wgc::WgcTarget::Monitor(display.hmonitor),
+                            config,
+                        )?))
+                    }
+                },
+            }
+        }
+        Some(VideoCaptureTarget::Window(id)) => {
+            if config.backend_preference == BackendPreference::WindowsDxgi {
+                return Err(PinrayError::Unsupported(
+                    "DXGI desktop duplication cannot capture a single window; use WindowsWgc or Auto"
+                        .into(),
+                ));
+            }
+            let hwnd = enumerate::find_window(id)?;
+            Some(Box::new(wgc::WgcVideoBackend::new(
+                wgc::WgcTarget::Window(hwnd),
+                config,
+            )?))
+        }
+    };
+
+    let audio: Option<Box<dyn AudioBackend>> = match &config.audio_capture {
+        None => None,
+        Some(AudioCapture::SystemMix) => Some(Box::new(wasapi::WasapiAudioBackend::new())),
+        Some(AudioCapture::Microphone(_)) => {
+            return Err(PinrayError::Unsupported(
+                "microphone capture is not implemented on windows yet".into(),
+            ));
+        }
+    };
+
+    let info = match (&video, &audio) {
+        (Some(video), _) => {
+            let mut info = video.info();
+            info.supports_audio = audio.is_some();
+            info
+        }
+        (None, Some(audio)) => audio.info(),
+        (None, None) => {
+            return Err(PinrayError::InvalidConfig(
+                "at least one of video_target or audio_capture must be set".into(),
+            ));
+        }
+    };
+
+    Ok(BackendBundle { info, video, audio })
 }

--- a/crates/platform-windows/src/wasapi.rs
+++ b/crates/platform-windows/src/wasapi.rs
@@ -1,0 +1,296 @@
+//! WASAPI loopback system-audio backend.
+//!
+//! A dedicated capture thread opens the default render endpoint in shared
+//! loopback mode and drains packets in a polling loop (event-driven buffering
+//! is unreliable for loopback pins across Windows versions). Frames are
+//! pushed into a bounded channel; `next_audio` drains it. If the consumer
+//! falls behind, the oldest unread packets are dropped.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use pinray_core::{
+    AudioBackend, AudioData, AudioFrame, BackendInfo, BackendKind, PinrayError, Result,
+    SampleFormat,
+};
+use tracing::{debug, warn};
+use windows::Win32::Media::Audio::{
+    AUDCLNT_BUFFERFLAGS_SILENT, AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_LOOPBACK,
+    IAudioCaptureClient, IAudioClient, IMMDeviceEnumerator, MMDeviceEnumerator, WAVE_FORMAT_PCM,
+    WAVEFORMATEX, WAVEFORMATEXTENSIBLE, eConsole, eRender,
+};
+use windows::Win32::Media::KernelStreaming::{KSDATAFORMAT_SUBTYPE_PCM, WAVE_FORMAT_EXTENSIBLE};
+use windows::Win32::Media::Multimedia::{KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, WAVE_FORMAT_IEEE_FLOAT};
+use windows::Win32::System::Com::{
+    CLSCTX_ALL, COINIT_MULTITHREADED, CoCreateInstance, CoInitializeEx, CoTaskMemFree,
+    CoUninitialize,
+};
+
+use crate::d3d::win_err;
+
+/// How many audio packets (~10 ms each) the channel buffers before dropping.
+const AUDIO_CHANNEL_CAPACITY: usize = 64;
+const POLL_INTERVAL: Duration = Duration::from_millis(4);
+
+struct MixFormat {
+    sample_rate: u32,
+    channels: u16,
+    block_align: u16,
+    sample_format: SampleFormat,
+}
+
+fn parse_mix_format(format: &WAVEFORMATEX) -> Result<MixFormat> {
+    let tag = format.wFormatTag as u32;
+    let bits = format.wBitsPerSample;
+
+    let int_format = |bits: u16| match bits {
+        16 => Ok(SampleFormat::I16),
+        32 => Ok(SampleFormat::I32),
+        other => Err(PinrayError::Unsupported(format!(
+            "unsupported PCM bit depth from WASAPI mix format: {other}"
+        ))),
+    };
+
+    let sample_format = if tag == WAVE_FORMAT_IEEE_FLOAT {
+        SampleFormat::F32
+    } else if tag == WAVE_FORMAT_PCM {
+        int_format(bits)?
+    } else if tag == WAVE_FORMAT_EXTENSIBLE {
+        let ext = unsafe { &*(format as *const WAVEFORMATEX as *const WAVEFORMATEXTENSIBLE) };
+        let sub_format = ext.SubFormat;
+        if sub_format == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT {
+            SampleFormat::F32
+        } else if sub_format == KSDATAFORMAT_SUBTYPE_PCM {
+            int_format(bits)?
+        } else {
+            return Err(PinrayError::Unsupported(format!(
+                "unsupported WASAPI mix sub-format: {sub_format:?}"
+            )));
+        }
+    } else {
+        return Err(PinrayError::Unsupported(format!(
+            "unsupported WASAPI mix format tag: {tag}"
+        )));
+    };
+
+    Ok(MixFormat {
+        sample_rate: format.nSamplesPerSec,
+        channels: format.nChannels,
+        block_align: format.nBlockAlign,
+        sample_format,
+    })
+}
+
+fn capture_loop(
+    stop: &AtomicBool,
+    tx: &SyncSender<AudioFrame>,
+    init_tx: &SyncSender<Result<()>>,
+) {
+    let mut initialized = false;
+    let result = (|| -> Result<()> {
+        let enumerator: IMMDeviceEnumerator =
+            unsafe { CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL) }
+                .map_err(|e| win_err("CoCreateInstance(MMDeviceEnumerator)", e))?;
+        let device = unsafe { enumerator.GetDefaultAudioEndpoint(eRender, eConsole) }
+            .map_err(|e| win_err("GetDefaultAudioEndpoint", e))?;
+        let client: IAudioClient = unsafe { device.Activate(CLSCTX_ALL, None) }
+            .map_err(|e| win_err("IMMDevice::Activate(IAudioClient)", e))?;
+
+        let format_ptr = unsafe { client.GetMixFormat() }
+            .map_err(|e| win_err("GetMixFormat", e))?;
+        let mix = {
+            let parsed = parse_mix_format(unsafe { &*format_ptr });
+            let init = unsafe {
+                client.Initialize(
+                    AUDCLNT_SHAREMODE_SHARED,
+                    AUDCLNT_STREAMFLAGS_LOOPBACK,
+                    // 200 ms buffer in 100-ns units; generous to survive
+                    // consumer stalls between polls.
+                    2_000_000,
+                    0,
+                    format_ptr,
+                    None,
+                )
+            };
+            unsafe { CoTaskMemFree(Some(format_ptr.cast())) };
+            init.map_err(|e| win_err("IAudioClient::Initialize", e))?;
+            parsed?
+        };
+
+        let capture: IAudioCaptureClient = unsafe { client.GetService() }
+            .map_err(|e| win_err("GetService(IAudioCaptureClient)", e))?;
+        unsafe { client.Start() }.map_err(|e| win_err("IAudioClient::Start", e))?;
+
+        initialized = true;
+        let _ = init_tx.try_send(Ok(()));
+        debug!(
+            rate = mix.sample_rate,
+            channels = mix.channels,
+            format = ?mix.sample_format,
+            "wasapi loopback capture started"
+        );
+
+        let mut sequence = 0u64;
+        while !stop.load(Ordering::Relaxed) {
+            std::thread::sleep(POLL_INTERVAL);
+
+            loop {
+                let packet_frames = unsafe { capture.GetNextPacketSize() }
+                    .map_err(|e| win_err("GetNextPacketSize", e))?;
+                if packet_frames == 0 {
+                    break;
+                }
+
+                let mut data_ptr: *mut u8 = std::ptr::null_mut();
+                let mut frames_read = 0u32;
+                let mut flags = 0u32;
+                let mut qpc_position = 0u64;
+                unsafe {
+                    capture.GetBuffer(
+                        &mut data_ptr,
+                        &mut frames_read,
+                        &mut flags,
+                        None,
+                        Some(&mut qpc_position),
+                    )
+                }
+                .map_err(|e| win_err("IAudioCaptureClient::GetBuffer", e))?;
+
+                let byte_count = frames_read as usize * mix.block_align as usize;
+                let bytes = if flags & AUDCLNT_BUFFERFLAGS_SILENT.0 as u32 != 0 {
+                    vec![0u8; byte_count]
+                } else {
+                    unsafe { std::slice::from_raw_parts(data_ptr, byte_count) }.to_vec()
+                };
+                unsafe { capture.ReleaseBuffer(frames_read) }
+                    .map_err(|e| win_err("ReleaseBuffer", e))?;
+
+                let frame = AudioFrame {
+                    // GetBuffer's QPC position is already in 100-ns units.
+                    stream_time_ns: qpc_position as i64 * 100,
+                    sequence,
+                    sample_rate: mix.sample_rate,
+                    channels: mix.channels,
+                    sample_format: mix.sample_format,
+                    data: AudioData::Interleaved(bytes),
+                };
+                sequence += 1;
+
+                // If the consumer is behind, drop the packet.
+                let _ = tx.try_send(frame);
+            }
+        }
+
+        unsafe { client.Stop() }.map_err(|e| win_err("IAudioClient::Stop", e))?;
+        Ok(())
+    })();
+
+    if let Err(error) = result {
+        if initialized {
+            warn!("wasapi capture loop terminated: {error}");
+        } else {
+            let _ = init_tx.try_send(Err(error));
+        }
+    }
+}
+
+pub(crate) struct WasapiAudioBackend {
+    worker: Option<(JoinHandle<()>, Arc<AtomicBool>)>,
+    rx: Option<Receiver<AudioFrame>>,
+}
+
+impl WasapiAudioBackend {
+    pub(crate) fn new() -> Self {
+        Self {
+            worker: None,
+            rx: None,
+        }
+    }
+
+    pub(crate) fn backend_info() -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::WindowsWasapi,
+            supports_audio: true,
+            zero_copy: false,
+            notes: "WASAPI shared-mode loopback of the default render endpoint (system mix)",
+        }
+    }
+}
+
+impl AudioBackend for WasapiAudioBackend {
+    fn info(&self) -> BackendInfo {
+        Self::backend_info()
+    }
+
+    fn start(&mut self) -> Result<()> {
+        if self.worker.is_some() {
+            return Ok(());
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = sync_channel::<AudioFrame>(AUDIO_CHANNEL_CAPACITY);
+        let (init_tx, init_rx) = sync_channel::<Result<()>>(1);
+
+        let thread_stop = Arc::clone(&stop);
+        let handle = std::thread::Builder::new()
+            .name("pinray-wasapi".into())
+            .spawn(move || {
+                let com = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+                capture_loop(&thread_stop, &tx, &init_tx);
+                if com.is_ok() {
+                    unsafe { CoUninitialize() };
+                }
+            })
+            .map_err(|e| PinrayError::Platform(format!("failed to spawn audio thread: {e}")))?;
+
+        match init_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(Ok(())) => {
+                self.worker = Some((handle, stop));
+                self.rx = Some(rx);
+                Ok(())
+            }
+            Ok(Err(error)) => {
+                let _ = handle.join();
+                Err(error)
+            }
+            Err(_) => {
+                stop.store(true, Ordering::Relaxed);
+                let _ = handle.join();
+                Err(PinrayError::Platform(
+                    "wasapi capture thread did not initialize within 5s".into(),
+                ))
+            }
+        }
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        if let Some((handle, stop)) = self.worker.take() {
+            stop.store(true, Ordering::Relaxed);
+            let _ = handle.join();
+        }
+        self.rx = None;
+        Ok(())
+    }
+
+    fn next_audio(&mut self, timeout: Option<Duration>) -> Result<AudioFrame> {
+        let rx = self
+            .rx
+            .as_ref()
+            .ok_or_else(|| PinrayError::Platform("wasapi backend not started".into()))?;
+
+        match timeout {
+            Some(timeout) => rx.recv_timeout(timeout).map_err(|error| match error {
+                RecvTimeoutError::Timeout => PinrayError::Timeout(timeout),
+                RecvTimeoutError::Disconnected => {
+                    PinrayError::Platform("wasapi capture thread terminated".into())
+                }
+            }),
+            None => rx
+                .recv()
+                .map_err(|_| PinrayError::Platform("wasapi capture thread terminated".into())),
+        }
+    }
+}

--- a/crates/platform-windows/src/wgc.rs
+++ b/crates/platform-windows/src/wgc.rs
@@ -1,0 +1,272 @@
+//! Windows Graphics Capture (WGC) video backend.
+//!
+//! Push-model: a free-threaded `Direct3D11CaptureFramePool` fires
+//! `FrameArrived` on a thread-pool thread, where the frame is copied to host
+//! memory and pushed into a bounded channel. `next_event` drains the channel.
+//! Frames that arrive while the channel is full are dropped and surfaced as
+//! a `Gap` event on the next call.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, sync_channel};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use pinray_core::{
+    BackendInfo, BackendKind, CaptureEvent, CursorMode, FrameData, GapEvent, GapReason,
+    PinrayError, PixelFormat, Rect, Result, SessionConfig, VideoBackend, VideoFrame,
+};
+use tracing::{debug, warn};
+use windows::Foundation::TypedEventHandler;
+use windows::Graphics::Capture::{
+    Direct3D11CaptureFramePool, GraphicsCaptureItem, GraphicsCaptureSession,
+};
+use windows::Graphics::DirectX::Direct3D11::IDirect3DDevice;
+use windows::Graphics::DirectX::DirectXPixelFormat;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D};
+use windows::Win32::Graphics::Dxgi::IDXGIDevice;
+use windows::Win32::Graphics::Gdi::HMONITOR;
+use windows::Win32::System::Com::CoIncrementMTAUsage;
+use windows::Win32::System::WinRT::Direct3D11::{
+    CreateDirect3D11DeviceFromDXGIDevice, IDirect3DDxgiInterfaceAccess,
+};
+use windows::Win32::System::WinRT::Graphics::Capture::IGraphicsCaptureItemInterop;
+use windows::core::{IInspectable, Interface, factory};
+
+use crate::d3d::{create_d3d_device, texture_to_host, win_err};
+
+/// Ensures the process has an MTA so WinRT activation works regardless of
+/// which thread the library is called from. The usage cookie is intentionally
+/// leaked: capture can be (re)started at any point in the process lifetime.
+fn ensure_mta() -> Result<()> {
+    static MTA: OnceLock<std::result::Result<(), String>> = OnceLock::new();
+    MTA.get_or_init(|| {
+        unsafe { CoIncrementMTAUsage() }
+            .map(|_cookie| ())
+            .map_err(|e| e.to_string())
+    })
+    .clone()
+    .map_err(|e| PinrayError::Platform(format!("CoIncrementMTAUsage: {e}")))
+}
+
+pub(crate) enum WgcTarget {
+    Monitor(HMONITOR),
+    Window(HWND),
+}
+
+/// `IDirect3DDevice` wraps the free-threaded D3D11 device, but windows-rs
+/// only auto-implements `Send` for WinRT runtime classes, not interfaces.
+struct SendDevice(IDirect3DDevice);
+unsafe impl Send for SendDevice {}
+
+pub(crate) struct WgcVideoBackend {
+    item: GraphicsCaptureItem,
+    device: ID3D11Device,
+    context: ID3D11DeviceContext,
+    winrt_device: SendDevice,
+    pixel_format: PixelFormat,
+    crop: Option<Rect>,
+    cursor_embedded: bool,
+    queue_depth: usize,
+    runtime: Option<(Direct3D11CaptureFramePool, GraphicsCaptureSession)>,
+    rx: Option<Receiver<VideoFrame>>,
+    sequence: Arc<AtomicU64>,
+    dropped: Arc<AtomicU32>,
+}
+
+impl WgcVideoBackend {
+    pub(crate) fn new(target: WgcTarget, config: &SessionConfig) -> Result<Self> {
+        ensure_mta()?;
+
+        if !GraphicsCaptureSession::IsSupported()
+            .map_err(|e| win_err("GraphicsCaptureSession::IsSupported", e))?
+        {
+            return Err(PinrayError::BackendUnavailable(
+                "Windows Graphics Capture is not supported on this system (needs Windows 10 1903+)"
+                    .into(),
+            ));
+        }
+
+        let interop = factory::<GraphicsCaptureItem, IGraphicsCaptureItemInterop>()
+            .map_err(|e| win_err("IGraphicsCaptureItemInterop factory", e))?;
+        let item: GraphicsCaptureItem = match target {
+            WgcTarget::Monitor(hmonitor) => unsafe { interop.CreateForMonitor(hmonitor) }
+                .map_err(|e| win_err("CreateForMonitor", e))?,
+            WgcTarget::Window(hwnd) => unsafe { interop.CreateForWindow(hwnd) }
+                .map_err(|e| win_err("CreateForWindow", e))?,
+        };
+
+        let (device, context) = create_d3d_device(None)?;
+        let dxgi_device: IDXGIDevice = device.cast().map_err(|e| win_err("IDXGIDevice cast", e))?;
+        let winrt_device: IDirect3DDevice =
+            unsafe { CreateDirect3D11DeviceFromDXGIDevice(&dxgi_device) }
+                .map_err(|e| win_err("CreateDirect3D11DeviceFromDXGIDevice", e))?
+                .cast()
+                .map_err(|e| win_err("IDirect3DDevice cast", e))?;
+
+        Ok(Self {
+            item,
+            device,
+            context,
+            winrt_device: SendDevice(winrt_device),
+            pixel_format: config.pixel_format,
+            crop: config.crop_rect,
+            cursor_embedded: config.cursor_mode == CursorMode::Embedded,
+            queue_depth: config.queue_depth as usize,
+            runtime: None,
+            rx: None,
+            sequence: Arc::new(AtomicU64::new(0)),
+            dropped: Arc::new(AtomicU32::new(0)),
+        })
+    }
+
+    pub(crate) fn backend_info() -> BackendInfo {
+        BackendInfo {
+            kind: BackendKind::WindowsWgc,
+            supports_audio: false,
+            zero_copy: false,
+            notes: "Windows Graphics Capture (Windows 10 1903+): display and window capture, cursor toggle",
+        }
+    }
+}
+
+impl VideoBackend for WgcVideoBackend {
+    fn info(&self) -> BackendInfo {
+        Self::backend_info()
+    }
+
+    fn start(&mut self) -> Result<()> {
+        if self.runtime.is_some() {
+            return Ok(());
+        }
+
+        let size = self.item.Size().map_err(|e| win_err("item.Size", e))?;
+        let frame_pool = Direct3D11CaptureFramePool::CreateFreeThreaded(
+            &self.winrt_device.0,
+            DirectXPixelFormat::B8G8R8A8UIntNormalized,
+            self.queue_depth as i32,
+            size,
+        )
+        .map_err(|e| win_err("CreateFreeThreaded", e))?;
+
+        let (tx, rx) = sync_channel::<VideoFrame>(self.queue_depth);
+        let device = self.device.clone();
+        let context = self.context.clone();
+        let pixel_format = self.pixel_format;
+        let crop = self.crop;
+        let sequence = Arc::clone(&self.sequence);
+        let dropped = Arc::clone(&self.dropped);
+
+        frame_pool
+            .FrameArrived(&TypedEventHandler::<
+                Direct3D11CaptureFramePool,
+                IInspectable,
+            >::new(move |pool, _| {
+                let Some(pool) = pool.as_ref() else {
+                    return Ok(());
+                };
+                let Ok(frame) = pool.TryGetNextFrame() else {
+                    return Ok(());
+                };
+
+                let result = (|| -> Result<VideoFrame> {
+                    let time_ns = frame
+                        .SystemRelativeTime()
+                        .map_err(|e| win_err("SystemRelativeTime", e))?
+                        .Duration
+                        * 100;
+                    let surface = frame.Surface().map_err(|e| win_err("frame.Surface", e))?;
+                    let access: IDirect3DDxgiInterfaceAccess = surface
+                        .cast()
+                        .map_err(|e| win_err("IDirect3DDxgiInterfaceAccess cast", e))?;
+                    let texture: ID3D11Texture2D = unsafe { access.GetInterface() }
+                        .map_err(|e| win_err("GetInterface", e))?;
+
+                    let copy = texture_to_host(&device, &context, &texture, crop, pixel_format)?;
+                    Ok(VideoFrame {
+                        stream_time_ns: time_ns,
+                        sequence: sequence.fetch_add(1, Ordering::Relaxed),
+                        width: copy.width,
+                        height: copy.height,
+                        stride: copy.stride,
+                        pixel_format,
+                        color_space: None,
+                        data: FrameData::Host(copy.data),
+                        damage: None,
+                    })
+                })();
+                let _ = frame.Close();
+
+                match result {
+                    Ok(video_frame) => {
+                        if tx.try_send(video_frame).is_err() {
+                            dropped.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                    Err(error) => warn!("wgc frame extraction failed: {error}"),
+                }
+                Ok(())
+            }))
+            .map_err(|e| win_err("FrameArrived", e))?;
+
+        let session = frame_pool
+            .CreateCaptureSession(&self.item)
+            .map_err(|e| win_err("CreateCaptureSession", e))?;
+
+        // Best-effort: not available on all Windows builds.
+        if let Err(error) = session.SetIsCursorCaptureEnabled(self.cursor_embedded) {
+            debug!("SetIsCursorCaptureEnabled failed (non-fatal): {error}");
+        }
+        if let Err(error) = session.SetIsBorderRequired(false) {
+            debug!("SetIsBorderRequired failed (non-fatal): {error}");
+        }
+
+        session
+            .StartCapture()
+            .map_err(|e| win_err("StartCapture", e))?;
+
+        self.runtime = Some((frame_pool, session));
+        self.rx = Some(rx);
+        debug!("wgc capture started");
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        if let Some((frame_pool, session)) = self.runtime.take() {
+            let _ = session.Close();
+            let _ = frame_pool.Close();
+        }
+        self.rx = None;
+        debug!("wgc capture stopped");
+        Ok(())
+    }
+
+    fn next_event(&mut self, timeout: Option<Duration>) -> Result<CaptureEvent> {
+        let dropped = self.dropped.swap(0, Ordering::Relaxed);
+        if dropped > 0 {
+            return Ok(CaptureEvent::Gap(GapEvent {
+                stream_time_ns: 0,
+                reason: GapReason::Dropped,
+                dropped_frames: Some(dropped),
+            }));
+        }
+
+        let rx = self
+            .rx
+            .as_ref()
+            .ok_or_else(|| PinrayError::Platform("wgc backend not started".into()))?;
+
+        let frame = match timeout {
+            Some(timeout) => rx.recv_timeout(timeout).map_err(|error| match error {
+                RecvTimeoutError::Timeout => PinrayError::Timeout(timeout),
+                RecvTimeoutError::Disconnected => {
+                    PinrayError::Platform("wgc frame channel disconnected".into())
+                }
+            })?,
+            None => rx
+                .recv()
+                .map_err(|_| PinrayError::Platform("wgc frame channel disconnected".into()))?,
+        };
+        Ok(CaptureEvent::Video(frame))
+    }
+}


### PR DESCRIPTION
Adds full Windows capture support with three backends:                                                                              
                                                                                                                                       
 - **DXGI** -- desktop duplication for display capture (pull-model, probe at build for Auto→WGC fallback)                             
 - **WGC** (Windows Graphics Capture) -- free-threaded pool with drop-counting Gap events                                             
 - **WASAPI** -- polling loopback thread for system audio                                                                             

 All backends use raw `windows` 0.62 bindings with no wrapper crates. Timestamps normalized to ns-since-boot (QPC epoch). Selection policy: Auto = DXGI for displays, WGC for windows; explicit preference honored.                                                       
                                                                                                       