### PR TITLE
Fix stride bug, surface the guide on docs.rs, add llms.txt reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 [Getting Started](docs/getting-started.md) •
 [Platform Support](docs/platforms.md) •
 [Troubleshooting](docs/troubleshooting.md) •
-[API Docs](https://docs.rs/pinray)
-
+[API Docs](https://docs.rs/pinray) •
+[Type reference (any platform)](https://docs.rs/pinray-core)
 
 <img width="1600" height="900" alt="pinray-banner" src="https://github.com/user-attachments/assets/763fcf60-1fa6-4e25-82d9-04c88563aca4" />
 

--- a/crates/core/src/frame.rs
+++ b/crates/core/src/frame.rs
@@ -27,6 +27,21 @@ pub enum PixelFormat {
     I420,
 }
 
+impl PixelFormat {
+    /// Bytes per pixel for packed RGB/RGBA formats.
+    ///
+    /// `None` for the planar/biplanar YUV formats, where a single
+    /// `width * bytes_per_pixel` row size doesn't apply (each plane has its
+    /// own stride and subsampling).
+    pub fn bytes_per_pixel(self) -> Option<usize> {
+        match self {
+            PixelFormat::Bgra8888 | PixelFormat::Rgba8888 => Some(4),
+            PixelFormat::Rgb888 => Some(3),
+            PixelFormat::Nv12 | PixelFormat::I420 => None,
+        }
+    }
+}
+
 /// Color space hint for interpreting pixel values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColorSpace {
@@ -91,6 +106,64 @@ pub struct VideoFrame {
     pub data: FrameData,
     /// Changed regions since the previous frame, when the backend knows.
     pub damage: Option<Vec<Rect>>,
+}
+
+impl VideoFrame {
+    /// Returns [`FrameData::Host`] bytes with row padding stripped, i.e.
+    /// `width * bytes_per_pixel` bytes per row instead of `stride`.
+    ///
+    /// `stride` can be wider than the tightly-packed row size (platform row
+    /// alignment); copying `data` directly into something that assumes tight
+    /// packing (a `rawvideo` pipe, an image encoder) silently skews every row
+    /// after the first. Use this instead of touching `data` directly.
+    ///
+    /// Returns `None` for non-[`FrameData::Host`] variants, or for pixel
+    /// formats without a well-defined bytes-per-pixel (see
+    /// [`PixelFormat::bytes_per_pixel`]).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use pinray_core::{FrameData, PixelFormat, VideoFrame};
+    ///
+    /// let (width, height, stride) = (2u32, 2u32, 12u32); // 4 padding bytes/row
+    /// let mut data = Vec::new();
+    /// for row in 0..height {
+    ///     data.extend(std::iter::repeat_n(row as u8, width as usize * 4));
+    ///     data.extend(std::iter::repeat_n(0xAA, (stride - width * 4) as usize));
+    /// }
+    /// let frame = VideoFrame {
+    ///     stream_time_ns: 0,
+    ///     sequence: 0,
+    ///     width,
+    ///     height,
+    ///     stride,
+    ///     pixel_format: PixelFormat::Bgra8888,
+    ///     color_space: None,
+    ///     data: FrameData::Host(data),
+    ///     damage: None,
+    /// };
+    ///
+    /// let tight = frame.to_tight_bytes().unwrap();
+    /// assert_eq!(tight.len(), (width * height * 4) as usize);
+    /// assert!(tight.iter().all(|&b| b != 0xAA)); // padding is gone
+    /// ```
+    pub fn to_tight_bytes(&self) -> Option<Vec<u8>> {
+        let FrameData::Host(buf) = &self.data else {
+            return None;
+        };
+        let bpp = self.pixel_format.bytes_per_pixel()?;
+        let row_bytes = self.width as usize * bpp;
+        if self.stride as usize == row_bytes {
+            return Some(buf.clone());
+        }
+        let mut out = Vec::with_capacity(row_bytes * self.height as usize);
+        for row in 0..self.height as usize {
+            let start = row * self.stride as usize;
+            out.extend_from_slice(&buf[start..start + row_bytes]);
+        }
+        Some(out)
+    }
 }
 
 /// Why a [`GapEvent`] was emitted.

--- a/crates/pinray/src/lib.rs
+++ b/crates/pinray/src/lib.rs
@@ -8,31 +8,6 @@
 //! is deliberately out of scope: feed frames to ffmpeg, WebRTC, wgpu, or
 //! your own pipeline.
 //!
-//! # Quick start
-//!
-//! ```no_run
-//! use std::time::Duration;
-//! use pinray::{AudioCapture, CaptureEvent, CaptureSession, SourceId, VideoCaptureTarget};
-//!
-//! # fn main() -> Result<(), pinray::PinrayError> {
-//! let mut session = CaptureSession::builder()
-//!     .video_target(VideoCaptureTarget::Display(SourceId::new("auto")))
-//!     .audio(AudioCapture::SystemMix)
-//!     .build()?;
-//!
-//! session.start()?;
-//! match session.next_event(Some(Duration::from_secs(5)))? {
-//!     CaptureEvent::Video(frame) => println!("{}x{}", frame.width, frame.height),
-//!     CaptureEvent::Audio(frame) => println!("{} Hz", frame.sample_rate),
-//!     other => println!("{other:?}"),
-//! }
-//! session.stop()?;
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! # Core concepts
-//!
 //! - [`CaptureSession`] — builder-configured lifecycle (`start` / `next_event`
 //!   / `stop`); [`enumerate_sources`] lists displays, windows, and audio
 //!   devices up front.
@@ -40,9 +15,7 @@
 //!   (dropped frames / backend restart), or `End`.
 //! - [`BackendPreference`] — `Auto` picks the right backend per platform;
 //!   [`CaptureSession::backend_info`] reports what was actually selected.
-//!
-//! Platform requirements, permissions, and per-backend limitations are
-//! documented in the repository's `docs/` folder.
+#![doc = include_str!("../../../docs/getting-started.md")]
 
 use pinray_core::{BackendBundle, BackendResolver, Result, SessionConfig};
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,13 +2,15 @@
 
 pinray captures screens, windows, and system audio through each OS's native API and hands you raw frames. This guide walks from install to your first frames. Full API reference: [docs.rs/pinray](https://docs.rs/pinray).
 
+> docs.rs builds the `pinray` and `pinray-platform-*` crates for a fixed target per platform (docs.rs can't link the native libraries for every OS at once, e.g. no `libpipewire` on their Linux builders) - the badge you land on may say Windows or macOS even if you're targeting Linux. The type definitions are identical on every platform regardless of which one the page was built for. For a build that's never redirected, see [docs.rs/pinray-core](https://docs.rs/pinray-core) - it has no native dependencies and always builds on the plain default target.
+
 ## Install
 
 ```console
 cargo add pinray
 ```
 
-Linux needs build-time system libraries (see [platforms.md](platforms.md#linux)); macOS and Windows need nothing extra.
+Linux needs build-time system libraries (see [platforms.md](https://github.com/Itz-Agasta/pinray/blob/main/docs/platforms.md#linux)); macOS and Windows need nothing extra.
 
 ## Capture your first frames
 
@@ -73,7 +75,30 @@ let mut session = CaptureSession::builder()
 session.start().unwrap();
 ```
 
-Audio arrives as `CaptureEvent::Audio` interleaved with video from `next_event`, or drain it directly with `session.next_audio(timeout)`. Audio-only sessions (no `video_target`) work too and never show permission dialogs on Linux.
+Audio arrives as `CaptureEvent::Audio` interleaved with video from `next_event`, or drain it directly with `session.next_audio(timeout)`.
+
+### Audio only, no video
+
+You don't need a `video_target` at all - an audio-only session is a first-class use case, not a side effect of the video API, and it never shows a permission dialog on Linux/Windows:
+
+```rust,no_run
+use std::time::Duration;
+use pinray::{AudioCapture, CaptureSession};
+
+let mut session = CaptureSession::builder()
+    .audio(AudioCapture::SystemMix)
+    .build()?;
+
+session.start()?;
+let frame = session.next_audio(Some(Duration::from_secs(3)))?;
+println!("{} Hz, {} ch", frame.sample_rate, frame.channels);
+session.stop()?;
+# Ok::<(), pinray::PinrayError>(())
+```
+
+Runnable version: `cargo run --example audio_smoke`.
+
+**Only `AudioCapture::SystemMix` (loopback / sink monitor - "everything the system plays") is implemented today.** `AudioCapture::Microphone(SourceId)` exists in the enum but no backend implements it yet - `.build()` itself fails with `PinrayError::Unsupported`, before a session is ever created. If you need mic input, pinray can't do that yet; track backend support before building on this path.
 
 ## Tuning
 
@@ -104,6 +129,49 @@ Include that output in bug reports - backend selection differs per machine.
 - `stream_time_ns` is monotonic and comparable between a session's audio and video streams. The epoch differs per platform (boot time on macOS/Windows, process-relative on Linux) - compute deltas, don't compare across machines.
 - `sequence` increments once per delivered frame per stream; a jump means the consumer fell behind and frames were dropped.
 - `CaptureEvent::Gap` reports drops and backend restarts explicitly.
+
+## Muxing frames into a video file
+
+pinray deliberately doesn't encode (see the crate docs) - piping `VideoFrame`/`AudioFrame` bytes into ffmpeg (or another encoder) is on you. Two mistakes are easy to make here and both produce a file that opens and plays fine while being silently wrong:
+
+**1. Row padding.** `stride` can be wider than `width * bytes_per_pixel` (platform row alignment). Copying `FrameData::Host` bytes straight into a `rawvideo` pipe skews every row after the first into a diagonal smear whenever that happens. Always go through [`VideoFrame::to_tight_bytes`] instead of touching `data` directly:
+
+```rust,no_run
+# use pinray::{CaptureEvent, CaptureSession};
+# fn handle(session: &mut CaptureSession) -> Result<(), Box<dyn std::error::Error>> {
+if let CaptureEvent::Video(frame) = session.next_event(None)? {
+    let tight = frame.to_tight_bytes().expect("Host frame, packed pixel format");
+    // write `tight`, not `frame.data`, to your rawvideo pipe
+}
+# Ok(())
+# }
+```
+
+**2. Frame rate.** `frame_rate` on the builder is a request, not a guarantee - Wayland portals and other push-driven backends deliver frames when the compositor damages the screen, not on a fixed clock. If you declare a constant `-framerate` to ffmpeg's `rawvideo` demuxer and just stream whatever arrives, a real-time recording plays back sped up or slowed down by however far the actual delivery rate was from what you declared, and `-shortest` will silently truncate whichever stream (usually audio) is longer. `stream_time_ns` is exactly what you need to fix this: track how many output frames are "due" by wall-clock delta and duplicate the last frame to fill the gap, instead of assuming one input frame equals one output frame:
+
+```rust,no_run
+# use pinray::{CaptureEvent, CaptureSession};
+# fn write_frame_to_pipe(_bytes: &[u8]) {}
+# fn pace(session: &mut CaptureSession) -> Result<(), Box<dyn std::error::Error>> {
+let target_fps = 30i64;
+let frame_interval_ns = 1_000_000_000 / target_fps;
+let mut next_due_ns: Option<i64> = None;
+let mut last_frame: Vec<u8> = Vec::new();
+
+loop {
+    let CaptureEvent::Video(frame) = session.next_event(None)? else { continue };
+    let tight = frame.to_tight_bytes().expect("Host frame, packed pixel format");
+    let due = next_due_ns.get_or_insert(frame.stream_time_ns + frame_interval_ns);
+    while frame.stream_time_ns >= *due {
+        write_frame_to_pipe(if last_frame.is_empty() { &tight } else { &last_frame });
+        *due += frame_interval_ns;
+    }
+    last_frame = tight;
+}
+# }
+```
+
+This duplicates frames to hit a constant declared rate rather than letting a variable capture cadence desync from wall-clock time. It's the minimum fix, not a full VFR-aware muxer - for anything beyond a quick recording, prefer a muxing library or encoder invocation that accepts explicit per-frame PTS derived from `stream_time_ns` instead of a declared constant rate.
 
 ## Runnable examples
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,172 @@
+# pinray
+
+Cross-platform screen and audio capture for Rust. Talks to each OS's native
+capture API (XDG portal + PipeWire and X11 on Linux, ScreenCaptureKit on
+macOS, DXGI/Windows Graphics Capture + WASAPI on Windows) and hands you raw
+video/audio frames with metadata intact - stride, pixel format, timestamps,
+sequence numbers, drop signals. Encoding is out of scope by design: pipe
+frames into ffmpeg, WebRTC, wgpu, or your own pipeline.
+
+This file is a flat, verified reference for agents integrating pinray, so you
+don't have to re-derive the API surface from docs.rs one page at a time.
+Everything below was checked against `crates/core/src/*.rs` directly, not
+guessed. If you're reading this from a released version, re-verify against
+docs.rs/pinray-core if in doubt - this file can drift from the crate.
+
+## Docs
+
+- Guide: docs.rs/pinray (crate-level docs) or `docs/getting-started.md` in the repo
+- Full type reference on any platform: docs.rs/pinray-core (no native deps, always builds untouched - the facade crate `pinray` builds docs.rs for one fixed target per platform because native libs like PipeWire aren't available on their Linux builders; type definitions are identical everywhere regardless)
+- Platform matrix / per-backend caveats: `docs/platforms.md`
+- Troubleshooting: `docs/troubleshooting.md`
+
+## Quick start
+
+```rust,no_run
+use std::time::Duration;
+use pinray::{AudioCapture, CaptureEvent, CaptureSession, SourceId, VideoCaptureTarget};
+
+let mut session = CaptureSession::builder()
+    .video_target(VideoCaptureTarget::Display(SourceId::new("auto")))
+    .audio(AudioCapture::SystemMix)
+    .build()?;
+session.start()?;
+match session.next_event(Some(Duration::from_secs(5)))? {
+    CaptureEvent::Video(f) => println!("{}x{}", f.width, f.height),
+    CaptureEvent::Audio(f) => println!("{} Hz", f.sample_rate),
+    other => println!("{other:?}"),
+}
+session.stop()?;
+```
+
+Audio-only, video-only, and video+audio are all first-class - `.video_target(...)` and `.audio(...)` are independent builder calls, `build()` only requires at least one of them set. For audio-only: skip `.video_target`, use `.audio(AudioCapture::SystemMix)`, drain with `.next_audio(timeout)` (or `.next_event` and match `CaptureEvent::Audio`). Runnable: `cargo run --example audio_smoke`. Video-only: skip `.audio`. Neither shows a permission dialog on Linux/Windows for audio-only; video (any mode) does on Wayland.
+
+## Core API
+
+`CaptureSession::builder() -> SessionBuilder`, then chain:
+`.video_target(VideoCaptureTarget)`, `.audio(AudioCapture)`,
+`.pixel_format(PixelFormat)`, `.restore_token(impl Into<String>)`,
+`.color_space(Option<ColorSpace>)`, `.cursor_mode(CursorMode)`,
+`.crop_rect(Option<Rect>)`, `.frame_rate(Option<u32>)`,
+`.queue_depth(u32)`, `.backend_preference(BackendPreference)`,
+`.build() -> Result<CaptureSession>`.
+
+`CaptureSession`: `.start()`, `.stop()` (both idempotent),
+`.is_running() -> bool`, `.backend_info() -> &BackendInfo`,
+`.next_event(Option<Duration>) -> Result<CaptureEvent>`,
+`.next_audio(Option<Duration>) -> Result<AudioFrame>`.
+`None` timeout blocks forever; `Some(Duration::ZERO)` is a non-blocking poll.
+
+Free functions: `available_backends() -> Vec<BackendInfo>`,
+`enumerate_sources() -> Result<Vec<CaptureSource>>`.
+
+## Types (verified against crates/core/src/*.rs)
+
+```rust
+enum CaptureEvent { Video(VideoFrame), Audio(AudioFrame), Gap(GapEvent), End }
+
+struct VideoFrame {
+    stream_time_ns: i64,   // monotonic within a session, comparable to AudioFrame's;
+                           // epoch is boot time on macOS/Windows, process-relative on Linux
+    sequence: u64,         // jump = dropped frames
+    width: u32,
+    height: u32,
+    stride: u32,           // bytes/row in FrameData::Host - can exceed width*bpp, see footgun #1
+    pixel_format: PixelFormat,
+    color_space: Option<ColorSpace>,
+    data: FrameData,
+    damage: Option<Vec<Rect>>,
+}
+impl VideoFrame {
+    // Strips row padding (stride -> width*bpp). Use this, not `data` directly.
+    fn to_tight_bytes(&self) -> Option<Vec<u8>>;
+}
+
+enum FrameData {
+    Host(Vec<u8>),              // the only variant any backend produces today
+    Dmabuf(DmabufFrame),        // reserved, unused
+    CvPixelBuffer(CvPixelBufferHandle), // reserved, unused
+    D3D11Texture(D3D11TextureHandle),   // reserved, unused
+}
+
+enum PixelFormat { Bgra8888, Rgba8888, Rgb888, Nv12, I420 }
+// All backends deliver Bgra8888 natively; Rgba8888 costs a CPU swizzle.
+// Nv12/I420 are not yet produced by any backend.
+impl PixelFormat { fn bytes_per_pixel(self) -> Option<usize>; } // None for Nv12/I420
+
+enum ColorSpace { Srgb, DisplayP3, Bt709, Bt2020 }
+enum CursorMode { Embedded, Hidden }
+struct Rect { x: i32, y: i32, width: u32, height: u32 }
+
+struct AudioFrame {
+    stream_time_ns: i64,   // same clock as VideoFrame::stream_time_ns
+    sequence: u64,
+    sample_rate: u32,
+    channels: u16,
+    sample_format: SampleFormat,
+    data: AudioData,
+}
+enum SampleFormat { I16, I32, F32, F64 }               // NOT S16/S24/S32/U8
+enum AudioData { Interleaved(Vec<u8>), Planar(Vec<Vec<u8>>) } // L R L R... vs one buffer/channel
+
+enum VideoCaptureTarget { Display(SourceId), Window(SourceId) }
+enum AudioCapture { SystemMix, Microphone(SourceId) }
+// Microphone: no backend implements this yet - CaptureSession::builder().audio(Microphone(_)).build()
+// fails eagerly with PinrayError::Unsupported on all three platforms (checked during backend
+// resolution inside build(), not lazily on first use).
+
+struct SourceId(pub String); // opaque; "auto" = primary display, no enumeration needed
+enum CaptureSource {          // what enumerate_sources() returns - NOT a struct with .id/.name/.kind
+    Display(DisplaySource),
+    Window(WindowSource),
+    SystemAudio(AudioDeviceSource),
+    Microphone(AudioDeviceSource),
+}
+struct DisplaySource { id: SourceId, name: String, width: u32, height: u32, scale_factor_milli: u32, is_primary: bool }
+struct WindowSource { id: SourceId, title: String, app_name: Option<String> }
+struct AudioDeviceSource { id: SourceId, name: String, is_default: bool }
+
+enum GapReason { Dropped, FormatChanged, BackendRestarted, Unknown }
+struct GapEvent { stream_time_ns: i64, reason: GapReason, dropped_frames: Option<u32> }
+
+enum BackendPreference { Auto, LinuxWaylandPortal, LinuxX11, MacScreenCaptureKit, WindowsDxgi, WindowsWgc }
+enum BackendKind { LinuxWaylandPortal, LinuxX11, LinuxPipeWireAudio, MacScreenCaptureKit, WindowsDxgi, WindowsWgc, WindowsWasapi }
+struct BackendInfo { kind: BackendKind, supports_audio: bool, zero_copy: bool, notes: &'static str } // field is `notes`, not `note`, and &'static str not Option<String>
+
+enum PinrayError {
+    InvalidConfig(String), BackendUnavailable(String), BackendNotSelected,
+    Timeout(Duration), Unsupported(String), Platform(String),
+}
+```
+
+Config defaults (`SessionConfig::default()`): `backend_preference: Auto`,
+`pixel_format: Bgra8888`, `color_space: Some(Srgb)`, `cursor_mode: Embedded`,
+`frame_rate: Some(60)`, `queue_depth: 2`. Build fails if neither
+`video_target` nor `audio_capture` is set.
+
+## Known footguns (found by actually building and running a recorder, not theoretical)
+
+1. **Stride vs width.** `VideoFrame.stride` can exceed `width * bytes_per_pixel`.
+   Copying `FrameData::Host` bytes straight into a `rawvideo` pipe or image
+   encoder skews every row after the first - no crash, just wrong pixels.
+   Fix: call `frame.to_tight_bytes()`, never touch `data` directly.
+
+2. **Frame rate is a request, not a guarantee.** Push-driven backends
+   (Wayland portal) deliver frames on damage events, not a fixed clock, even
+   if you set `.frame_rate(Some(30))`. Declaring a constant `-framerate` to
+   ffmpeg's rawvideo demuxer while streaming whatever arrives produces a file
+   that plays back sped up or slowed down, and `-shortest` silently truncates
+   whichever stream is longer. Fix: pace output frames using `stream_time_ns`
+   deltas (duplicate the last frame to fill gaps) instead of assuming one
+   captured frame equals one output frame at your declared rate. Full
+   worked example: `docs/getting-started.md` "Muxing frames into a video file".
+
+3. **`FrameData` has 4 variants, 1 live.** Every backend currently produces
+   only `Host`; the other three are reserved for future zero-copy paths.
+   You still have to handle them in a match (or use `to_tight_bytes()`,
+   which already does and returns `None` for them).
+
+## MSRV / stability
+
+Rust 1.88 (let-chains). Crate is 0.2.x and pre-1.0: minor versions may break
+the API. Pin a minor version for stability.


### PR DESCRIPTION
- Found a real, silent-wrong bug integrating pinray into a test recorder: `VideoFrame.stride` can exceed the tightly-packed row size, and there was no API to handle it - fixed with `VideoFrame::to_tight_bytes()`.
- docs.rs was a dead end: the getting-started guide lived only in `docs/`, invisible from the crate's own docs.rs page, and the page's Windows-target redirect (needed because docs.rs can't link libpipewire) was easy to misread as meaning the type definitions differ per platform. Embedded the guide via `include_str!`, documented the redirect, and pointed to `pinray-core` as the always-correct type reference.
- Documented the frame-rate footgun (declared constant fps vs push-driven actual capture cadence silently desyncs muxed output) and gave audio-only its own first-class example instead of a single prose line.
- Added `llms.txt`: a flat reference checked line-by-line against `crates/core/src/*.rs`, for agents integrating the crate.
