### PR TITLE
Surface Wayland portal restore token via CaptureSession::restore_token()

### DIFF
--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -54,6 +54,14 @@ pub trait VideoBackend: Send {
     fn start(&mut self) -> Result<()>;
     fn stop(&mut self) -> Result<()>;
     fn next_event(&mut self, timeout: Option<Duration>) -> Result<CaptureEvent>;
+
+    /// Returns the portal restore token negotiated for this session, if any.
+    ///
+    /// Only meaningful for backends that go through a permission portal
+    /// (Wayland's XDG Desktop Portal); other backends keep the default `None`.
+    fn restore_token(&self) -> Option<String> {
+        None
+    }
 }
 
 /// A platform audio capture implementation; same timeout contract as

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -37,6 +37,16 @@ impl CaptureSession {
         &self.backend_info
     }
 
+    /// Returns the portal restore token negotiated for this session, if any.
+    ///
+    /// Available once the session is built on backends that use a permission
+    /// portal (Wayland); other backends return `None`.
+    pub fn restore_token(&self) -> Option<String> {
+        self.video_backend
+            .as_ref()
+            .and_then(|video| video.restore_token())
+    }
+
     pub fn is_running(&self) -> bool {
         self.running
     }

--- a/crates/pinray/examples/wayland_smoke.rs
+++ b/crates/pinray/examples/wayland_smoke.rs
@@ -13,20 +13,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
+    let restore_token = std::env::args().nth(1);
+
     println!("[1] building session (video + system audio)...");
-    let mut session = CaptureSession::builder()
+    let mut builder = CaptureSession::builder()
         .backend_preference(BackendPreference::LinuxWaylandPortal)
         .video_target(VideoCaptureTarget::Display(SourceId::new(
             "portal-default-display",
         )))
         .audio(AudioCapture::SystemMix)
-        .pixel_format(PixelFormat::Bgra8888)
-        .build()?;
+        .pixel_format(PixelFormat::Bgra8888);
+    if let Some(token) = restore_token {
+        println!("[1] using supplied restore token");
+        builder = builder.restore_token(token);
+    }
+    let mut session = builder.build()?;
 
     println!("[2] selected backend: {:?}", session.backend_info().kind);
     println!("[3] starting session...");
     session.start()?;
-    println!("[4] session started, entering capture loop...");
+    println!(
+        "[4] session started, restore_token={:?}, entering capture loop...",
+        session.restore_token()
+    );
 
     let mut videos = 0u32;
     let mut audios = 0u32;

--- a/crates/pinray/src/lib.rs
+++ b/crates/pinray/src/lib.rs
@@ -81,6 +81,14 @@ impl CaptureSession {
         self.inner.backend_info()
     }
 
+    /// Returns the portal restore token negotiated for this session, if any.
+    ///
+    /// Available once the session is built on backends that use a permission
+    /// portal (Wayland); other backends return `None`.
+    pub fn restore_token(&self) -> Option<String> {
+        self.inner.restore_token()
+    }
+
     pub fn is_running(&self) -> bool {
         self.inner.is_running()
     }

--- a/crates/platform-linux/src/wayland/mod.rs
+++ b/crates/platform-linux/src/wayland/mod.rs
@@ -78,6 +78,7 @@ pub(super) struct VideoSize {
 
 struct WaylandVideoBackend {
     info: BackendInfo,
+    restore_token: Option<String>,
     control_tx: mpsc::Sender<ControlMessage>,
     event_rx: mpsc::Receiver<CaptureEvent>,
     worker: Option<thread::JoinHandle<Result<()>>>,
@@ -100,7 +101,7 @@ impl WaylandVideoBackend {
             .next()
             .ok_or_else(|| PinrayError::Platform("portal returned no screencast stream".into()))?;
 
-        if let Some(token) = restore_token {
+        if let Some(token) = &restore_token {
             tracing::info!(restore_token = %token, "portal returned restore token");
         }
 
@@ -136,6 +137,7 @@ impl WaylandVideoBackend {
                 zero_copy: false,
                 notes: "Wayland video via XDG Desktop Portal + PipeWire",
             },
+            restore_token,
             control_tx,
             event_rx,
             worker: Some(worker),
@@ -146,6 +148,10 @@ impl WaylandVideoBackend {
 impl VideoBackend for WaylandVideoBackend {
     fn info(&self) -> BackendInfo {
         self.info.clone()
+    }
+
+    fn restore_token(&self) -> Option<String> {
+        self.restore_token.clone()
     }
 
     fn start(&mut self) -> Result<()> {

--- a/crates/platform-linux/src/wayland/mod.rs
+++ b/crates/platform-linux/src/wayland/mod.rs
@@ -102,7 +102,7 @@ impl WaylandVideoBackend {
             .ok_or_else(|| PinrayError::Platform("portal returned no screencast stream".into()))?;
 
         if let Some(token) = &restore_token {
-            tracing::info!(restore_token = %token, "portal returned restore token");
+            tracing::debug!(restore_token = %token, "portal returned restore token");
         }
 
         let (control_tx, control_rx) = mpsc::channel();

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,7 +27,7 @@ pinray needs Rust 1.88+. `rustup update stable`.
 Neither `XDG_SESSION_TYPE=wayland`/`WAYLAND_DISPLAY` nor `DISPLAY` is set - you're on a headless host. Video needs a session; audio-only sessions still work if PipeWire runs.
 
 **Portal dialog appears every run**
-Capture the restore token: after the first session the portal returns one (logged at info level; API surfacing is on the roadmap), then pass `.restore_token(token)`.
+Capture the restore token: after the first session read it from `session.restore_token()`, persist it, then pass `.restore_token(token)` on the next run to skip the dialog.
 
 **`GetImage on the root window failed ... Xwayland root is not readable`**
 You forced `LinuxX11` inside a Wayland session. Rootless Xwayland has no readable root - use the Wayland backend (`Auto` does this), or run a real Xorg session.


### PR DESCRIPTION
Closes #4. The Wayland XDG portal hands back a `restore_token` after the user approves a screencast, which apps can persist and replay to skip the permission dialog on later runs. The backend was only logging the token and discarding it, so there was no API to retrieve it. `session.config()` never reflected it either, since config holds what the caller *sent in*,
not what the portal returns.

## Changes

- `VideoBackend::restore_token()` trait method, default `None`; only the Wayland backend overrides it. Other platforms unaffected.
- Wayland backend stores the token on its struct instead of only logging it.
- `CaptureSession::restore_token()` exposed through core and the facade.
- `wayland_smoke` example prints the token and accepts one as a CLI arg, so the dialog-skip round trip can be exercised manually.
- Doc fix in `troubleshooting.md` (was marked "on the roadmap").

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the Wayland portal restore token so apps can persist it and skip the screencast permission dialog on later runs. Other backends are unchanged.

- **New Features**
  - Added `VideoBackend::restore_token()` (default `None`); Wayland backend overrides it and stores the token.
  - Surfaced token via `CaptureSession::restore_token()` in core and the `pinray` facade.
  - Updated `wayland_smoke` example: accepts a token via CLI and prints the negotiated token for round-trip testing.
  - Documentation: troubleshooting now points to `session.restore_token()` for capturing and reusing the token.

- **Refactors**
  - Wayland: log the portal restore token at debug level to reduce noise.

<sup>Written for commit b5426740c5cbe2f527449e1b1eeaa0da9ef84fc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Itz-Agasta/pinray/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

